### PR TITLE
be smarter about markup

### DIFF
--- a/chrome/content/zotfile/pdfextract/pdfjs/src/canvas.js
+++ b/chrome/content/zotfile/pdfextract/pdfjs/src/canvas.js
@@ -688,12 +688,14 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         var lastCharSpace = (annot.markup[quad].charAt(markupEnd) == ' ');
         if (isSpace && lastCharSpace) return;
 
-        if (!isSpace && !lastCharSpace &&
-            charDims.x >= annot.markupGeom[quad].brx + charDims.spaceWidth) {
+        if (!isSpace && !lastCharSpace && charDims.spaceWidth != 0 &&
+            charDims.x > annot.markupGeom[quad].brx + charDims.spaceWidth) {
           annot.markup[quad] += ' ';
         }
-        annot.markupGeom[quad].brx = charDims.x + charDims.width;
-        annot.markup[quad] += character;
+        if (annot.markupGeom[quad].brx < charDims.x + charDims.width) {
+          annot.markupGeom[quad].brx = charDims.x + charDims.width;
+          annot.markup[quad] += character;
+        }
       }
     },
     showText: function canvasGraphicsShowText(str, skipTextSelection) {


### PR DESCRIPTION
1. don't infer 0-width spaces
2. don't add characters to markup that overlap previously-added characters
