### PR TITLE
Period as delimiter and "set to lower case" option

### DIFF
--- a/chrome/content/zotfile/options.js
+++ b/chrome/content/zotfile/options.js
@@ -81,7 +81,7 @@ function updatePreferenceWindow(which) {
     
     // Use Zotero to Rename
     if(which=="zotrename" || which=="all") {
-        setting=disablePreference("useZoteroToRename", ['renameFormat', 'renameFormat-label', 'renameFormat-des1', 'renameFormat-des2', 'renameFormat-des3', 'renameFormat-des4', 'renameFormat_patent', 'renameFormat_patent-label', 'truncate_title', 'truncate_title_max', 'max_titlelength', 'max_authors','truncate_authors', 'add_etal', 'etal', 'authors_delimiter', 'userInput', 'userInput_Default', 'replace_blanks'], !revert);
+        setting=disablePreference("useZoteroToRename", ['renameFormat', 'renameFormat-label', 'renameFormat-des1', 'renameFormat-des2', 'renameFormat-des3', 'renameFormat-des4', 'renameFormat_patent', 'renameFormat_patent-label', 'truncate_title', 'truncate_title_max', 'max_titlelength', 'max_authors','truncate_authors', 'add_etal', 'etal', 'authors_delimiter', 'userInput', 'userInput_Default', 'replace_blanks', 'lower_case'], !revert);
         if (which=="all" && setting) {
             disablePreference("add_etal", "etal", false);
             disablePreference("userInput", "userInput_Default", false);

--- a/chrome/content/zotfile/options.xul
+++ b/chrome/content/zotfile/options.xul
@@ -37,7 +37,8 @@
 				<preference id="pref-zotfile-userInput" name="extensions.zotfile.userInput" type="bool"/>   
 				<preference id="pref-zotfile-userInput_Default" name="extensions.zotfile.userInput_Default" type="string"/>   				
 				<preference id="pref-zotfile-replace_blanks" name="extensions.zotfile.replace_blanks" type="bool"/>   
-				
+        <preference id="pref-zotfile-lower_case" name="extensions.zotfile.lower_case" type="bool"/>
+        
 				<preference id="pref-zotfile-confirmation" name="extensions.zotfile.confirmation" type="bool"/>                                                                                              				
 				<preference id="pref-zotfile-confirmation_batch_ask" name="extensions.zotfile.confirmation_batch_ask" type="bool"/>
 				<preference id="pref-zotfile-confirmation_batch" name="extensions.zotfile.confirmation_batch" type="int"/>
@@ -272,6 +273,10 @@
 									   <textbox id="id-zotfile-userInput_Default" preference="pref-zotfile-userInput_Default" width="100"/>
 								   </hbox>     
 
+                   <hbox style="margin: 0">         
+                     <checkbox id="id-zotfile-lower_case" label="Set in lower case" preference="pref-zotfile-lower_case"/>
+                   </hbox>
+								   
 								   <hbox style="margin: 0">					
 									   <checkbox id="id-zotfile-replace_blanks" label="Replace Blanks" preference="pref-zotfile-replace_blanks"/>
 								   </hbox>

--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -766,7 +766,7 @@ Zotero.ZotFile = {
         var max_authors=(this.prefs.getBoolPref("truncate_authors")) ? this.prefs.getIntPref("max_authors") : 500;
         if (numauthors<=max_authors) add_etal=0;
         if (numauthors>max_authors) numauthors = 1;
-		var delimiter=this.prefs.getCharPref("authors_delimiter");
+        var delimiter=this.prefs.getCharPref("authors_delimiter");
         var j=0;
         for (i=0; i < creators.length; i++) {
             if (j<numauthors && creatorType.indexOf(creators[i].creatorTypeID)!=-1) {
@@ -922,11 +922,11 @@ Zotero.ZotFile = {
         if (!this.prefs.getBoolPref("useZoteroToRename")) {
             
             filename=this.replaceWildcard(item, rename_rule);
-        //var filename =  author + "_" + year + "_" + title;
+            //var filename =  author + "_" + year + "_" + title;
 
             // Strip potentially invalid characters
-            // (code line adopted from Zotero)
-            filename = filename.replace(/[\/\\\?\*:|"<>\.]/g, '');
+            // (code line adopted from Zotero, modified to accept periods)
+            filename = filename.replace(/[\/\\\?\*:|"<>]/g, '');
 
             // replace multiple blanks in filename with single blank & remove whitespace
             //var filename = filename.replace(/ {2,}/g, ' ');
@@ -934,6 +934,9 @@ Zotero.ZotFile = {
 
             // replace blanks with '_' if option selected
             if (this.prefs.getBoolPref("replace_blanks"))  filename = filename.replace(/ /g, '_');
+            
+            // set to lower case
+            if (this.prefs.getBoolPref("lower_case"))  filename = filename.toLowerCase();
 
             // remove all the accents and other strange characters from filename
             if (Zotero.version[0]>=3 && this.prefs.getBoolPref("removeDiacritics")) filename = Zotero.Utilities.removeDiacritics(filename);

--- a/defaults/preferences/zotfile.js
+++ b/defaults/preferences/zotfile.js
@@ -25,6 +25,7 @@ pref("extensions.zotfile.import", true);
 pref("extensions.zotfile.autoRename", true);
 pref("extensions.zotfile.autoRenameIfMultipleAttachments", true);
 pref("extensions.zotfile.replace_blanks", false);
+pref("extensions.zotfile.lower_case", false);
 pref("extensions.zotfile.subfolder", false);
 pref("extensions.zotfile.subfolderFormat", "/%w/%y");
 pref("extensions.zotfile.userInput", false);


### PR DESCRIPTION
Here are the changes.
I left the lower case option enabled, since I tried it at my home computer and it somehow works. I'm guessing there may be come conflict with local preferences? Not sure.
If you grep the key `lower_case` all relevant changes should come up.
