### PR TITLE
New wildcard expansion mechanism

### DIFF
--- a/chrome/locale/de-DE/zotfile.properties
+++ b/chrome/locale/de-DE/zotfile.properties
@@ -43,10 +43,10 @@ renaming.imported						=	'%S' (importiert)
 renaming.linked							=	'%S' (verlinkt)
 renaming.renamed						=	ZotFile: Unbenannte Anhänge
 renaming.addUserInput.prompt			=	Geben Sie eine Dateiendung ein (Abbrechen drücken um keine Endung anzufügen)\n\nUrsprünglicher Dateiname\n%1$S\n\nNeuer Dateiname\n%2$S (Ihre Eingabe)
-renaming.errorFormat.closing			=	Fehler im Umbennenungs-Format: unpassende schließende '%1$S' bei %2$S.
-renaming.errorFormat.opening			=	Fehler im Umbennenungs-Format: unpassende öffnende '%1$S' bei %2$S.
-renaming.errorFormat.left				=	fehlende linke Platzhalter für exklusiven Operator '|' bei %S.
-renaming.errorFormat.right				=	fehlende rechte Platzhalter für exklusiven Operator '|' bei %S.
+renaming.errorFormat.missingOpening = Öffnende '%1$S' statt '%3$S' an Position %2$S benötigt. Denken Sie daran, daß Argumentblöcke von Wildcard Modifikatoren unmittelbar aufeinanderfolgen müssen.  
+renaming.errorFormat.unmatchedOpening = Klammer '%1$S' an Position %2$S ist nicht geschlossen.
+renaming.errorFormat.missingBlock = Sie haben nicht genug Argumentblöcke für den Wildcard-Modifikator an Position %1$S angegeben. Denken Sie daran, daß Argumentblöcke von Wildcard Modifikatoren unmittelbar aufeinanderfolgen müssen.  
+renaming.errorFormat.wildcardLastChar = Fehler beim Umbenennen: Der letzte Buchstabe darf nicht '\%' sein.
 
 file.removeFolderFailed					=	ZotFile war nicht in der Lage den alten Ordner zu löschen. Wahrscheinlich befinden sich weitere Dateien in dem Ordner.
 file.invalidSourceFolder				=	Der Quellordner ist nicht korrekt. Bitte ändern Sie den Quellordner unter 'Zotfile Einstellungen'.

--- a/chrome/locale/en-US/zotfile.properties
+++ b/chrome/locale/en-US/zotfile.properties
@@ -42,10 +42,11 @@ renaming.imported						=	'%S' (imported)
 renaming.linked							=	'%S' (linked)
 renaming.renamed						=	ZotFile: Renamed attachments
 renaming.addUserInput.prompt			=	Enter file suffix (press Cancel to add nothing)\n\nOriginal Filename\n%1$S\n\nNew Filename\n%2$S (YOUR INPUT)
-renaming.errorFormat.closing			=	Error in renaming format: unmatched closing '%1$S' at position %2$S.
-renaming.errorFormat.opening			=	Error in renaming format: unmatched opening '%1$S' at position %2$S.
-renaming.errorFormat.left				=	missing left wildcard for exclusive operator '|' at position %S.
-renaming.errorFormat.right				=	missing right wildcard for exclusive operator '|' at position %S.
+renaming.errorFormat.missingOpening = Error in renaming format: Expected opening '%1$S' at position %2$S but instead found '%3$S'. Remember not to put any whitespace between blocks of wildcard modifiers. 
+renaming.errorFormat.unmatchedOpening = Error in renaming format: Unmatched opening '%1$S' at position %2%S. Remember not to put any whitespace between blocks of wildcard modifiers. 
+renaming.errorFormat.missingBlock = Error in renaming format: Not enough blocks for wildcard modifier at position %1$S. Remember not to put any whitespace between blocks of wildcard modifiers. 
+renaming.errorFormat.wildcardLastChar = Error in renaming format: Last character is '\%'.
+
 
 file.removeFolderFailed					=	ZotFile was unable delete the old folder probably because other files are in the folder.
 file.invalidSourceFolder				=	The source folder is not valid. Please change the the source folder under Zotero-Actions-Zotfile Preferences. You might have to use a custom folder.

--- a/chrome/locale/fr-FR/zotfile.properties
+++ b/chrome/locale/fr-FR/zotfile.properties
@@ -42,10 +42,10 @@ renaming.imported						=	'%S' (importé)
 renaming.linked							=	'%S' (lié)
 renaming.renamed						=	ZotFile: Pièce(s) jointe(s) renommée(s)
 renaming.addUserInput.prompt			=	Entrez un suffixe pour ce fichier (appuyer sur Annuler pour ne rien ajouter)\n\nNom de fichier original\n%1$S\n\nNouveau nom de fichier\n%2$S (VOTRE SAISIE)
-renaming.errorFormat.closing			=	Erreur dans le format de renommage: '%1$S' fermante orpheline à la position %2$S.
-renaming.errorFormat.opening			=	Erreur dans le format de renommage: '%1$S' ouvrante orpheline à la position %2$S.
-renaming.errorFormat.left				=	Il manque un joker à gauche de l'opérateur exclusif '|' à la position %S.
-renaming.errorFormat.right				=	Il manque un joker à droite de l'opérateur exclusif '|' à la position %S.
+renaming.errorFormat.missingOpening = TODO
+renaming.errorFormat.unmatchedOpening = TODO
+renaming.errorFormat.missingBlock = TODO
+renaming.errorFormat.wildcardLastChar = TODO
 
 file.removeFolderFailed					=	ZotFile n'a pas pu supprimer l'ancien dossier car d'autres fichiers sont dedans.
 file.invalidSourceFolder				=	Le dossier source n'est pas valide. Changez-le s'il vous plaît dans les Préférences de Zotfile (via l'icône rouage de Zotero). Il vous faudra peut-être utilisé un dossier personnalisé.


### PR DESCRIPTION
Hi, 

I was not happy with the wildcard expansion mechanism as it did not allow me to organize my files as I wanted to. Therefore, I've reimplemented it in a cleaner and more flexible way which should be easier to manage in the future. The reason why it did this is that now also 'wildcard modifiers' are supported (see commit message for description and examples). 

The french error messages are still missing (marked by TODO in the zotero.properties file) and there are a few design decisions to make for you (marked by TODO inside zotfile.js). However, the code runs as is so you can try it out! 

Maybe this is overkill for the average "non-computer-affine" user, but in this case one could hide the most commonly used functionality behind options and still leave the modifiers there for the experts. Please tell me what you think about this.

Best,

Simon

PS: If you're not happy with the symbols I chose, change them to your liking.
