### PR TITLE
Allows %x as placeholder for rename rules

### DIFF
--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -1240,7 +1240,7 @@ Zotero.ZotFile = {
         table["%T"] = item_type_string;
         // pages
         table["%f"] = zitem.getField("pages");
-        // pages
+        // extra
         table["%x"] = zitem.getField("extra");
         // return
         return table;


### PR DESCRIPTION
Matches "Extra" field

Additional info: This is required, because there seems to be no way to sort book chapters by their chapter number. I'm manually entering the chapter number into the "Extra" field and would like to have this sort order maintained when I export to the tablet.
