### PR TITLE
Option to auto-link files in BaseDir instead of importing them

### DIFF
--- a/chrome/content/zotfile/options.xul
+++ b/chrome/content/zotfile/options.xul
@@ -77,6 +77,8 @@
 				<!--<preference id="pref-zotfile-pdfExtraction-MenuItem" name="extensions.zotfile.pdfExtraction.MenuItem" type="bool"/> -->
 				<preference id="pref-zotfile-pdfExtraction-NoteTruePage" name="extensions.zotfile.pdfExtraction.NoteTruePage" type="bool"/> 
 				<preference id="pref-zotfile-pdfExtraction-NoteFullCite" name="extensions.zotfile.pdfExtraction.NoteFullCite" type="bool"/> 
+
+				<preference id="pref-zotfile-autolink" name="extensions.zotfile.autolink" type="bool"/>                                                                                              
 				
 				
 				
@@ -370,6 +372,7 @@
 							<button id="id-zotfile-add-search" label="&attachments-on-tablet;" oncommand="Zotero.ZotFile.createSavedSearch('tablet');"/>
 							<button id="id-zotfile-add-search2" label="&modified-attachments-on-tablet;" oncommand="Zotero.ZotFile.createSavedSearch('tablet_modified');"/>
 							</hbox>
+						  <checkbox id="id-zotfile-autolink" label="&link-instead-of-attach;" preference="pref-zotfile-autolink"/>
 						
 						</groupbox>  																													
 						

--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -156,6 +156,17 @@ Zotero.ZotFile = {
                         getService(Components.interfaces.nsIPrefService);
             this.prefs = this.prefs.getBranch("extensions.zotfile.");
 
+            // monkey-patch Zotero.Attachments
+            Zotero.Attachments.importFromFile = (function (self, original) {
+              return function (file, sourceItemID, libraryID) {
+                if (self.prefs.getBoolPref("autolink") && Zotero.Attachments.getBaseDirectoryRelativePath(file.persistentDescriptor).indexOf('attachments:') == 0) {
+                  return Zotero.Attachments.linkFromFile(file, sourceItemID);
+                } else {
+                  return original.apply(this, arguments);
+                }
+              }
+            })(this, Zotero.Attachments.importFromFile);
+
             this.ffPrefs = Components.classes["@mozilla.org/preferences-service;1"].
                         getService(Components.interfaces.nsIPrefService).getBranch("browser.download.");
             // save some preferences

--- a/chrome/locale/en-US/options.dtd
+++ b/chrome/locale/en-US/options.dtd
@@ -81,3 +81,4 @@
 <!ENTITY add-saved-searches "Add Saved Searches">
 <!ENTITY attachments-on-tablet "Attachments on Tablet">
 <!ENTITY modified-attachments-on-tablet "Modified Attachments on Tablet">
+<!ENTITY link-instead-of-attach "Automatically link to file under base directory when adding instead of adding to repository">

--- a/defaults/preferences/zotfile.js
+++ b/defaults/preferences/zotfile.js
@@ -18,6 +18,7 @@ pref("extensions.zotfile.add_etal", true);
 pref("extensions.zotfile.etal", " et al");
 pref("extensions.zotfile.authors_delimiter", "_");
 pref("extensions.zotfile.removeDiacritics", false);
+pref("extensions.zotfile.autolink", false);
 pref("extensions.zotfile.removePeriods", false);
 pref("extensions.zotfile.confirmation", true);
 pref("extensions.zotfile.confirmation_batch_ask", true);


### PR DESCRIPTION
This patch adds an option so files that reside in the basedir always get linked instead of imported. I know all the pros of doing imports instead of links, and I'm aware of the tablet-mode in zotfile, but I keep my pdf's on dropbox so I can mark them up from my ereader and tablet, so a one-way copy doesn't suffice. With this patch I can drop in my PDFs as normal and still keep them on dropbox.
