### PR TITLE
Rename files without moving or attaching

### DIFF
--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -1926,14 +1926,16 @@ Zotero.ZotFile = {
               // create a nslFile Object of the destination folder
               var dir = this.createFile(destination);
               // move file to new location
-              if(destination.trim() == "/") { 
-              	//if there's no destination, then the file will be renamed in-place
-              	alert("You have not set the location to move the file. File will only be renamed.");
-		file.moveTo(null, filename);
-	      }
-	      else {
-	      	file.moveTo(dir, filename);
-	      }
+              if(destination.trim() == "/")
+							{
+									this.infoWindow(this.ZFgetString('general.warning'), 
+										'No location is mentioned to move the attachment. File will only be renamed.');
+									file.moveTo(null, filename);
+							}
+							else
+							{
+									file.moveTo(dir, filename);
+							}
             }
             catch(err) {
                 if(err.name == "NS_ERROR_FILE_IS_LOCKED")

--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -1928,6 +1928,7 @@ Zotero.ZotFile = {
               // move file to new location
               if(destination.trim() == "/")
 							{
+									//no place to move the file, so rename it in-place
 									this.infoWindow(this.ZFgetString('general.warning'), 
 										'No location is mentioned to move the attachment. File will only be renamed.');
 									file.moveTo(null, filename);

--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -1926,11 +1926,11 @@ Zotero.ZotFile = {
               // create a nslFile Object of the destination folder
               var dir = this.createFile(destination);
               // move file to new location
-              if(destination.trim() == "/")
+              if(destination.trim() == this.folderSep)
 							{
 									//no place to move the file, so rename it in-place
 									this.infoWindow(this.ZFgetString('general.warning'), 
-										'No location is mentioned to move the attachment. File will only be renamed.');
+										'No location is mentioned to move the attachment. File is renamed only.');
 									file.moveTo(null, filename);
 							}
 							else

--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -1926,7 +1926,14 @@ Zotero.ZotFile = {
               // create a nslFile Object of the destination folder
               var dir = this.createFile(destination);
               // move file to new location
-              file.moveTo(dir, filename);
+              if(destination.trim() == "/") { 
+              	//if there's no destination, then the file will be renamed in-place
+              	alert("You have not set the location to move the file. File will only be renamed.");
+		file.moveTo(null, filename);
+	      }
+	      else {
+	      	file.moveTo(dir, filename);
+	      }
             }
             catch(err) {
                 if(err.name == "NS_ERROR_FILE_IS_LOCKED")


### PR DESCRIPTION
In case user doesn't specify any location to move new/existing files, then also there should be provision to rename files, I think. So, even when the destination is nothing, file will be renamed in-place where the file is actually located in the disk.