### PR TITLE
rename linked files correctly in place

### DIFF
--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -1972,6 +1972,11 @@ Zotero.ZotFile = {
         
         var origModDate = file.lastModifiedTime;
         try {       
+            if(location.trim() == this.folderSep) {
+                //no place to move the file, so rename it in-place
+                this.infoWindow(this.ZFgetString('general.warning'), 'Custom location for files not set. File is renamed only.');
+                location = file.parent.path;
+            }
             var dest = this.createFile(location);
             dest.append(filename);
 


### PR DESCRIPTION
rename linked files correctly in place, if user does not specify any location to move/copy files to.

if the user does not specify a location to copy files to, the current code crashes on line 1975: "location" is set to '/' and creating a file with this location returns -1. "dest.append(filename)" on the following line errors, because "dest" was set to -1.