### PR TITLE
Extend compatibility to Juris-M

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -31,6 +31,20 @@
 	     <em:maxVersion>4.*</em:maxVersion>
 	   </Description>
 	 </em:requires>
+	<em:targetApplication>
+		<Description>
+			<em:id>juris-m@juris-m.github.io</em:id>
+			<em:minVersion>3.0b1</em:minVersion>
+			<em:maxVersion>4.*</em:maxVersion>
+		</Description>
+	</em:targetApplication>
+	<em:requires>
+	   <Description>
+	     <em:id>juris-m@juris-m.github.io</em:id>
+	     <em:minVersion>1.*</em:minVersion>
+	     <em:maxVersion>4.*</em:maxVersion>
+	   </Description>
+	 </em:requires>
     <!-- Front End MetaData -->
     <em:localized>
       <Description>


### PR DESCRIPTION
The ID of Juris-M (formerly MLZ) had to be changed to satisfy code-signing requirements. Since the latest release, users have reported that ZotFile cannot be installed alongside Juris-M - it's failing with a declaration that ZotFile is incompatible. This patch would get us going again.

Thanks - and thanks for all your work on ZotFile!

Frank Bennett

