### PR TITLE
Extend compatibility to Juris-M

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -25,6 +25,13 @@
 			<em:maxVersion>4.*</em:maxVersion>
 		</Description>
 	</em:targetApplication>
+	<em:targetApplication>
+		<Description>
+			<em:id>juris-m@juris-m.github.io</em:id>
+			<em:minVersion>3.0b1</em:minVersion>
+			<em:maxVersion>4.*</em:maxVersion>
+		</Description>
+	</em:targetApplication>
     <em:localized>
       <Description>
 	<em:locale>en-US</em:locale>


### PR DESCRIPTION
I have had to change the ID of Juris-M to satisfy code signing requirements (it used to be released with the Zotero ID). Since the latest Juris-M release, users are reporting that ZotFile installs fail with a compatibility warning. This patch should get us going again.

Thanks for all your work on ZotFile!

Frank Bennett
