### PR TITLE
Cast title field to string

### DIFF
--- a/chrome/content/zotfile/wildcards.js
+++ b/chrome/content/zotfile/wildcards.js
@@ -41,6 +41,8 @@ Zotero.ZotFile.Wildcards = new function() {
     }
 
     function truncateTitle(title) {
+        title = '' + title
+
         // truncate title after : . and ?
         if(Zotero.ZotFile.prefs.getBoolPref("truncate_title")) {
             var truncate = title.search(/:|\.|\?|\!/);


### PR DESCRIPTION
This fixes this error if an item's title is a number. Zotero does no casting.
> TypeError: title.search is not a function 
> (chrome://zotfile/content/zotfile.js, 1363)