### PR TITLE
Correct spelling mistake in fr-FR locale

### DIFF
--- a/chrome/locale/fr-FR/zotfile.properties
+++ b/chrome/locale/fr-FR/zotfile.properties
@@ -51,7 +51,7 @@ renaming.errorFormat.left				=	Il manque un joker à gauche de l'opérateur excl
 renaming.errorFormat.right				=	Il manque un joker à droite de l'opérateur exclusif '|' à la position %S.
 
 file.removeFolderFailed					=	ZotFile n'a pas pu supprimer l'ancien dossier car d'autres fichiers sont dedans.
-file.invalidSourceFolder				=	Le dossier source n'est pas valide. Changez-le s'il vous plaît dans les Préférences de Zotfile (via l'icône rouage de Zotero). Il vous faudra peut-être utilisé un dossier personnalisé.
+file.invalidSourceFolder				=	Le dossier source n'est pas valide. Changez-le s'il vous plaît dans les Préférences de Zotfile. Il vous faudra peut-être utiliser un dossier personnalisé.
 
 tablet.oldTagName						=	Dans ZotFile 2.1, le marqueur pour les pièces jointes de tablette '_READ' a été modifié au profit de '_tablet'. SVP, n'utilisez pas et ne changer pas le marqueur '_tablet' manuellement!
 tablet.regularItemTagged				=	Un document régulier de Zotero a le marqueur '%S'. Ce marqueur doit seulement être utilisé par zotfile et ne pas être assigné manuellement.


### PR DESCRIPTION
utilisé->utiliser
(and remove the reference to the Gear icon which no longer exist in Zotero 5.0)