### PR TITLE
Add "Zotfile Preferences" to menu "Tools"

### DIFF
--- a/chrome/content/zotfile/overlay.xul
+++ b/chrome/content/zotfile/overlay.xul
@@ -80,6 +80,10 @@
     <menuitem id="zotfile-options" insertafter="zotero-tb-actions-prefs" label="&zotfile-options.label;" oncommand="Zotero.ZotFile.openPreferenceWindow();"/>
 	</menupopup>
 	
+	<menupopup id="menu_ToolsPopup">
+	<menuitem id="zotfile-options" insertafter="menu_preferences" label="&zotfile-options.label;" oncommand="Zotero.ZotFile.openPreferenceWindow();"/>
+	</menupopup>
+	
 	<!-- Include the main extension logic -->
 	<script src="chrome://zotero/content/include.js"/>
 	<script src="chrome://zotfile/content/include.js"/>	


### PR DESCRIPTION
Fix #262
In Zotero 5.0, "the Actions (gear icon) menu has been removed from the toolbar, as all options are now available in menus".