### PR TITLE
Use relinkAttachment to rename stored file

### DIFF
--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -947,7 +947,8 @@ Zotero.ZotFile = new function() {
             yield att.renameAttachmentFile(filename);
             // change title of attachment item
             att.setField('title', filename);
-            yield att.saveTx();
+            path = path.split(this.folderSep).slice(0, -1).concat([filename]).join(this.folderSep);
+            yield att.relinkAttachmentFile(path)
             // notification
             if (verbose) this.messages_report.push(this.ZFgetString('renaming.imported', [filename]));
             return att;


### PR DESCRIPTION
With "Attach stored copy of file(s)", I found that "Attach New File" removed the attachment from the source folder, and the attachment was added to the Zotero item, but threw an error when I attempted to open it. The problem was with renaming. ZotFile was generating the new filename, and applying it to the attachment Title field, but the underlying filename was not being updated in Zotero storage---so the file was there, but the path Zotero generated to access it was incorrect.

This patch saves the attachment with Zotero's `relinkAttachmentFile()` function, which implicitly calls `saveTx()` after updating the fillename.