### PR TITLE
Allow installation on Zotero 5.*

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -22,7 +22,7 @@
 		<Description>
 			<em:id>zotero@chnm.gmu.edu</em:id>
 			<em:minVersion>3.0b1</em:minVersion>
-			<em:maxVersion>4.*</em:maxVersion>
+			<em:maxVersion>5.*</em:maxVersion>
 		</Description>
 	</em:targetApplication>
 	<em:targetApplication>


### PR DESCRIPTION
Currently, Zotero 5.* beta will not allow installation of ZotFile.