### PR TITLE
Fix 'undefined' in collectionPath due to parent being false

### DIFF
--- a/chrome/content/zotfile/utils.js
+++ b/chrome/content/zotfile/utils.js
@@ -59,7 +59,7 @@ Zotero.ZotFile.Utils = new function() {
     this.getCollectionPathsOfItem = function(item) {
         var getCollectionPath = function(collectionID) {
             var collection = Zotero.Collections.get(collectionID);
-            if (collection.parent == false)  return collection.name
+            if (collection.parent === false)  return collection.name
 
             return OS.Path.normalize(getCollectionPath(collection.parentID) + Zotero.ZotFile.folderSep + collection.name);
         };

--- a/chrome/content/zotfile/utils.js
+++ b/chrome/content/zotfile/utils.js
@@ -59,7 +59,7 @@ Zotero.ZotFile.Utils = new function() {
     this.getCollectionPathsOfItem = function(item) {
         var getCollectionPath = function(collectionID) {
             var collection = Zotero.Collections.get(collectionID);
-            if (collection.parent == null)  return collection.name
+            if (collection.parent == false)  return collection.name
 
             return OS.Path.normalize(getCollectionPath(collection.parentID) + Zotero.ZotFile.folderSep + collection.name);
         };


### PR DESCRIPTION
Per https://github.com/zotero/zotero/blob/be8db4fc50d3895ce12a55ed032ab8853da43323/chrome/content/zotero/xpcom/data/collection.js#L149 , `Collection.parentID`, same as  `Collection.parent`, should be either Integer or `false`. However the code in `Zotero.ZotFile.Utils.getCollectionPathsOfItem` tries to check it with `null`. This causes deeper `getCollectionPath(null)` return `undefined`. 

This should fix #268, fix #331, fix #300.