### PR TITLE
Fix: root files are placed under `undefined`

### DIFF
--- a/chrome/content/zotfile/wildcards.js
+++ b/chrome/content/zotfile/wildcards.js
@@ -5,6 +5,9 @@
  */
 Zotero.ZotFile.Wildcards = new function() {
 
+    var _this = this;
+    this.emptyCollectionPlaceholder = "EMPTY_COLLECTION_NAME";
+
     /*
      * Performs a binary search that returns the index of the array before which the
      * search should be inserted into the array to maintain a sorted order.
@@ -376,7 +379,7 @@ Zotero.ZotFile.Wildcards = new function() {
                     };
 
                     var collectionPaths = lookup;
-                    if (collectionPaths.length === 0)  return "";
+                    if (collectionPaths.length === 0)  return _this.emptyCollectionPlaceholder;
                     if (collectionPaths.length === 1)  return collectionPaths[0];
 
                     var title = table['%t'];

--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -455,16 +455,15 @@ Zotero.ZotFile = new function() {
      */
     this.formatSubfolder = function(item, format) {
         if (format == '') return '';
-        if(format.slice(-1) == this.folderSep) format = format.slice(0, -1);
+        if (format.slice(-1) == this.folderSep) format = format.slice(0, -1);
+        if (format[0] == this.folderSep) format = format.slice(1);
         var subfolder = this.Wildcards.replaceWildcard(item, format);
-        if (subfolder[0] == this.folderSep) subfolder = subfolder.slice(1);
-        // replace invalid characters        
+        // replace invalid characters
         subfolder = OS.Path.split(subfolder).components
             .map(s => s == '' ? 'undefined' : s)
+            .filter(s => s != this.Wildcards.emptyCollectionPlaceholder)
             .map(s => Zotero.File.getValidFileName(s))
             .join(this.folderSep);
-        if (format.replace(/[\/\\]/g,'') == '%c')
-            subfolder = subfolder.replace(/undefined[\/\\]?/g, '');
         return OS.Path.normalize(subfolder);
     };
 


### PR DESCRIPTION
When files are not in any collection, the returned collection name is an empty string, which will cause `formatSubfolder` to interpret it as an undefined attribute. In other cases like `%a` being empty, this might seem legit. However when collection is empty, it means the file is not under any collection, in which case IMO the file should be put in root directory.