### PR TITLE
Update renaming rule for item beloging to multiple folders.

### DIFF
--- a/chrome/content/zotfile/wildcards.js
+++ b/chrome/content/zotfile/wildcards.js
@@ -359,6 +359,9 @@ Zotero.ZotFile.Wildcards = new function() {
         if (exclusive !== "") {
             str.push(exclusive);
         }
+
+        var wildcards_collection_high = JSON.parse(Zotero.ZotFile.prefs.getCharPref("wildcards.collection.high"));
+        var wildcards_collection_low = JSON.parse(Zotero.ZotFile.prefs.getCharPref("wildcards.collection.low"));
         for (var j = last + 1; j < wildcards.length; ++j) {
             // add rule content before wildcard
             str.push(rule.substring(wildcards[j - 1] + 2, wildcards[j]));
@@ -381,6 +384,32 @@ Zotero.ZotFile.Wildcards = new function() {
                     var collectionPaths = lookup;
                     if (collectionPaths.length === 0)  return _this.emptyCollectionPlaceholder;
                     if (collectionPaths.length === 1)  return collectionPaths[0];
+                    var priority = 0
+                    var index = collectionPaths.length
+                    collectionPaths.forEach(function (value) {
+                        // unescape for matching of unicode characters
+                        value = unescape(value)
+                        if (wildcards_collection_high.includes(value)) {
+                            if (priority < 2) {
+                                priority = 2
+                                index = wildcards_collection_high.indexOf(value)
+                                array_choice = []
+                            } else {
+                                index = Math.min(index, wildcards_collection_high.indexOf(value))
+                            }
+                        } else if (wildcards_collection_low.includes(value)) {
+                            if (priority == 0) {
+                                index = Math.min(index, wildcards_collection_low.indexOf(value))
+                            }
+                        } else if (priority == 0) {
+                            priority = 1
+                        }
+                    });
+                    if (priority == 2) {
+                        return wildcards_collection_high[index]
+                    } else if (priority == 0) {
+                        return wildcards_collection_low[index]
+                    }
 
                     var title = table['%t'];
                     var idx = selectFromList(collectionPaths, title);

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -40,6 +40,8 @@ pref("extensions.zotfile.info_window_duration_clickable",8000);
 pref("extensions.zotfile.info_window_duration",6000);
 pref("extensions.zotfile.wildcards.default",'{"a": "author", "A": {"field": "author", "operations":[{"function":"exec","regex": "\\\\w{1}"},{"function":"toUpperCase"}]}, "F": "authorLastF", "I": "authorInitials", "d": "editor", "D": {"field": "editor", "operations":[{"function":"exec","regex": "\\\\w{1}"},{"function":"toUpperCase"}]}, "L": "editorLastF", "l": "editorInitials", "t": "titleFormated", "h": "shortTitle", "j": "publicationTitle", "s": "journalAbbreviation", "p": "publisher", "w": {"default": "publisher", "audioRecording": "label", "bill": "legislativeBody", "case": "court", "computerProgram": "company", "film": "distributor", "journalArticle": "publicationTitle", "magazineArticle": "publicationTitle", "newspaperArticle": "publicationTitle", "patent": "issuingAuthority", "presentation": "meetingName", "radioBroadcast": "network", "report": "institution", "thesis": "university", "tvBroadcast": "network"}, "n": "patentNumber", "i": "assignee", "y": {"field": {"default": "date", "patent": "issueDate"}, "operations":[{"function":"exec","regex": "\\\\d{4}"}]}, "v": "volume", "e": "issue", "T": "itemType", "f": "pages", "x": "extra", "c": "collectionPaths", "g": "authorLastG", "q":"lastAuthor", "Q":"lastAuthor_lastInitial", "u":"lastAuthor_lastf", "U":"lastAuthor_initials"}');
 pref("extensions.zotfile.wildcards.user",'{}');
+pref("extensions.zotfile.wildcards.collection.high",'[]');
+pref("extensions.zotfile.wildcards.collection.low",'[]');
 
 pref("extensions.zotfile.tablet", false);
 pref("extensions.zotfile.tablet.dest_dir", "");


### PR DESCRIPTION
If any of the folders are included in "extensions.zotfile.wildcards.collection.high", the folder is selected as the first folder in the variable.
If all of the folders are included in "extensions.zotfile.wildcards.collection.low", the folder is selected as the first folder in the variable.
Otherwise, the dialog is activated as before.