### PR TITLE
Detailed log messages when renaming, removal of empty directories not enforced

### DIFF
--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -942,7 +942,13 @@ Zotero.ZotFile = new function() {
             // erase old attachment, remove file and folder
             yield att.eraseTx();
             yield OS.File.remove(path);
-            yield this.removeEmptyFolders(OS.Path.dirname(path));
+            try {
+              yield this.removeEmptyFolders(OS.Path.dirname(path));
+        		}
+        		catch (e){
+              // instead of yielding the empty folder, push warning message
+              if(verbose) this.messages_report.push(this.ZFgetString('removing.warning.empty', [path]));
+        		}
             // notification
             if (verbose) this.messages_report.push(this.ZFgetString('renaming.imported', [filename]));
             return attNew;

--- a/chrome/locale/en-US/zotfile.properties
+++ b/chrome/locale/en-US/zotfile.properties
@@ -17,8 +17,8 @@ general.warning.topLevel.msg			=	Attachments skipped because entry is top level 
 general.warning.topLevel.tablet.msg	=	Attachments skipped because entry is top level item.
 
 general.warning.tabletStatus				    =	ZotFile Warning: Skipped attachments
-general.warning.tabletStatus.msg			  =	Attachments skipped because of tablet status.
-general.warning.tabletStatus.tablet.msg	=	Attachments skipped because of tablet status.
+general.warning.tabletStatus.msg			  =	Attachments skipped due to tablet status.
+general.warning.tabletStatus.tablet.msg	=	Attachments skipped due to tablet status.
 
 general.warning.renamingFailed				    =	ZotFile Warning: Skipped attachments
 general.warning.renamingFailed.msg			  =	Attachments skipped because renaming failed.
@@ -54,6 +54,9 @@ uninstallZFReader						=	ZotFile has transfered most of your preferences from Zo
 watchFolder.newFile						=	ZotFile: New file in source folder
 watchFolder.clickRename					=	(click here to rename and attach this file to the currently selected Zotero item)
 watchFolder.noRegularItem				=	No regular Zotero item selected.
+
+removing.warning = '%S' could not be removed.
+removing.warning.empty = Empty directory ''%S' could not be removed.
 
 renaming.clickMoveRename				=	(click here to move and rename)
 renaming.renamingFailed					=	Zotfile failed to automatically rename an attachment.

--- a/chrome/locale/en-US/zotfile.properties
+++ b/chrome/locale/en-US/zotfile.properties
@@ -6,6 +6,24 @@ general.warning							=	ZotFile Warning
 general.warning.skippedAtt				=	ZotFile Warning: Skipped attachments
 general.warning.skippedAtt.msg			=	Attachments skipped because they are top-level items, snapshots or the file does not exist.
 general.warning.skippedAtt.tablet.msg	=	Attachments skipped because they are already renamed, on the tablet, top-level items, snapshots or the file does not exist.
+
+#general.warning							=	ZotFile Warning
+general.warning.noFile				     =	ZotFile Warning: Skipped attachments
+general.warning.noFile.msg			   =	Attachments skipped because file does not exist.
+general.warning.noFile.tablet.msg	 =	Attachments skipped because file does not exist.
+
+general.warning.topLevel				  =	ZotFile Warning: Skipped attachments
+general.warning.topLevel.msg			=	Attachments skipped because entry is top level item.
+general.warning.topLevel.tablet.msg	=	Attachments skipped because entry is top level item.
+
+general.warning.tabletStatus				    =	ZotFile Warning: Skipped attachments
+general.warning.tabletStatus.msg			  =	Attachments skipped because of tablet status.
+general.warning.tabletStatus.tablet.msg	=	Attachments skipped because of tablet status.
+
+general.warning.renamingFailed				    =	ZotFile Warning: Skipped attachments
+general.warning.renamingFailed.msg			  =	Attachments skipped because renaming failed.
+general.warning.renamingFailed.tablet.msg	=	Attachments skipped because renaming failed.
+
 general.error							=	ZotFile Error
 general.report							=	ZotFile Report
 general.newAttachment					=	ZotFile: New attachment


### PR DESCRIPTION
Detailed log messages when renaming (in English only).

Removal of empty directories not enforced, see https://github.com/jlegewie/zotfile/issues/389
(not sure about whether that is a "clean" solution)


