### PR TITLE
Firefox 60 compatibility fixes

### DIFF
--- a/chrome/content/zotfile/ProgressWindow.js
+++ b/chrome/content/zotfile/ProgressWindow.js
@@ -114,7 +114,7 @@ Zotero.ZotFile.ProgressWindow = function(_window){
 		var newDescription = _progressWindow.document.createElement("description");
 		
 		var parts = Zotero.Utilities.parseMarkup(text);
-		for each(var part in parts) {
+		for (let part of parts) {
 			if (part.type == 'text') {
 				var elem = _progressWindow.document.createTextNode(part.text);
 			}

--- a/chrome/content/zotfile/openPDF-protocol-handler.js
+++ b/chrome/content/zotfile/openPDF-protocol-handler.js
@@ -11,7 +11,7 @@ var OpenPDFExtension = {
         // parsing code copied from Zotero
         // https://github.com/zotero/zotero/blob/60e0d79e01bf83daf8682c0bc088fbeaba496198/components/zotero-protocol-handler.js#L1017-L1049
         var userLibraryID = Zotero.Libraries.userLibraryID;
-        var uriPath = uri.path;
+        var uriPath = uri.pathQueryRef;
         if (!uriPath) {
             return 'Invalid URL';
         }

--- a/chrome/content/zotfile/options.js
+++ b/chrome/content/zotfile/options.js
@@ -212,6 +212,26 @@ var updateFolderIcon = Zotero.Promise.coroutine(function* (which, revert) {
     }
 }.bind(Zotero.ZotFile));
 
+async function chooseDestinationDirectory() {
+	var folder = await Zotero.ZotFile.chooseDirectory();
+	if (folder != '') {
+		Zotero.ZotFile.setPref('dest_dir', folder);
+		updateFolderIcon('dest', false);
+		onImportPrefChange();
+	}
+}
+
+async function onImportPrefChange() {
+	if (!document.getElementById('pref-zotfile-import').value) return;
+	// If changing from default to custom, choose directory now
+	if (document.getElementById('pref-zotfile-dest_dir').value == '') {
+		let destDir = await Zotero.ZotFile.chooseDirectory();
+		// DEBUG: What if cancelled?
+		Zotero.ZotFile.setPref('dest_dir', destDir);
+		updateFolderIcon('dest', true);
+	}
+}
+
 var checkFolderLocation = Zotero.Promise.coroutine(function* (folder) {
     var path = this.getPref(folder);
     return path != '' && (yield OS.File.exists(path));

--- a/chrome/content/zotfile/options.xul
+++ b/chrome/content/zotfile/options.xul
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero-platform/content/preferences.css"?>
 
 <!DOCTYPE window SYSTEM "chrome://zotfile/locale/options.dtd">
 
@@ -79,7 +80,7 @@
 							<separator/>
 							<hbox  style="margin: 0"  align="center">
 								<textbox id="id-zotfile-source_dir" preference="pref-zotfile-source_dir" flex="1" onchange="updateFolderIcon('source',false); "/>
-								<button id="id-zotfile-source_dir-button" label="&choose;" oncommand="var folder = Zotero.ZotFile.chooseDirectory(); if(folder != '') {Zotero.ZotFile.setPref('source_dir', folder); updateFolderIcon('source', false);}"/>
+								<button id="id-zotfile-source_dir-button" label="&choose;" oncommand="Zotero.ZotFile.chooseDirectory().then((folder) => { if(folder != '') {Zotero.ZotFile.setPref('source_dir', folder); updateFolderIcon('source', false);} });"/>
 								<image id="id-zotfile-source_dir-clear" width='16' height='16' hidden="false"/>
 								<image id="id-zotfile-source_dir-ok" src="chrome://zotfile/skin/accept.png" hidden="true"/>
 								<image id="id-zotfile-source_dir-error" src="chrome://zotfile/skin/exclamation.png" hidden="true"/>
@@ -92,12 +93,12 @@
 							<description style="width: 420px">&target-location-desc;</description>
 							<separator/>
 
-							<radiogroup id="id-zotfile-import" preference="pref-zotfile-import" oncommand="if(document.getElementById('pref-zotfile-import').value) if(document.getElementById('pref-zotfile-dest_dir').value=='') {Zotero.ZotFile.setPref('dest_dir', Zotero.ZotFile.chooseDirectory()); updateFolderIcon('dest',true);}">
-								<radio label="&attach-stored-copy;" value="true" oncommand="updatePreferenceWindow('dest');"/>
+							<radiogroup id="id-zotfile-import" preference="pref-zotfile-import">
+								<radio label="&attach-stored-copy;" value="true" oncommand="updatePreferenceWindow('dest'); onImportPrefChange();"/>
 								<hbox  style="margin: 0"  align="center">
-									<radio label="&custom-location;" value="false" oncommand="updatePreferenceWindow('dest');"/>
+									<radio label="&custom-location;" value="false" oncommand="updatePreferenceWindow('dest'); onImportPrefChange();"/>
 									<textbox id="id-zotfile-dest_dir" preference="pref-zotfile-dest_dir" flex="1" onchange="updateFolderIcon('dest',false);"/>
-									<button id="id-zotfile-dest_dir-button" label="&choose;" oncommand="var folder = Zotero.ZotFile.chooseDirectory(); if(folder != '') {Zotero.ZotFile.setPref('dest_dir', folder); updateFolderIcon('dest', false);}"/>
+									<button id="id-zotfile-dest_dir-button" label="&choose;" oncommand="chooseDestinationDirectory()"/>
 									<image id="id-zotfile-dest_dir-clear" width='16' height='16' hidden="false"/>
 									<image id="id-zotfile-dest_dir-ok" src="chrome://zotfile/skin/accept.png" hidden="true"/>
 									<image id="id-zotfile-dest_dir-error" src="chrome://zotfile/skin/exclamation.png" hidden="true"/>
@@ -136,7 +137,7 @@
 							<label id="id-zotfile-tablet-baseFolder" value="&base-folder;" control="id-zotfile-tablet-dest_dir"/>
 							<hbox style="margin: 0" align="center">
 								<textbox id="id-zotfile-tablet-dest_dir" preference="pref-zotfile-tablet-dest_dir" flex="1" onchange="updateFolderIcon('tablet');"/>
-								<button id="id-zotfile-tablet-dest_dir-button" label="&choose;" oncommand="var folder=Zotero.ZotFile.chooseDirectory(); if(folder!='') {Zotero.ZotFile.setPref('tablet.dest_dir', folder); updateFolderIcon('tablet',false);}"/>
+								<button id="id-zotfile-tablet-dest_dir-button" label="&choose;" oncommand="Zotero.ZotFile.chooseDirectory().then((folder) => { if(folder!='') {Zotero.ZotFile.setPref('tablet.dest_dir', folder); updateFolderIcon('tablet',false);} });"/>
 								<button id="id-zotfile-tablet-dest_dir-show" label="&show-folder;" oncommand="Zotero.ZotFile.showFolder(Zotero.ZotFile.Tablet.getTabletLocationFile());"/>
 								<image id="id-zotfile-tablet-ok" src="chrome://zotfile/skin/accept.png" hidden="true"/>
 								<image id="id-zotfile-tablet-error" src="chrome://zotfile/skin/exclamation.png" hidden="true"/>

--- a/chrome/content/zotfile/pdfAnnotations.js
+++ b/chrome/content/zotfile/pdfAnnotations.js
@@ -34,7 +34,7 @@ Zotero.ZotFile.pdfAnnotations = new function() {
         this.popplerExtractorFileName += '-' + Zotero.platform;
         if (Zotero.isWin) this.popplerExtractorFileName += '.exe';
         // extractor path
-        this.popplerExtractorPath = OS.Path.join(Zotero.getZoteroDirectory().path, 'ExtractPDFAnnotations', this.popplerExtractorFileName);
+        this.popplerExtractorPath = OS.Path.join(Zotero.DataDirectory.dir, 'ExtractPDFAnnotations', this.popplerExtractorFileName);
     };
 
     this.getAnnotations = Zotero.Promise.coroutine(function* (attIDs) {

--- a/chrome/content/zotfile/pdfOutline.js
+++ b/chrome/content/zotfile/pdfOutline.js
@@ -136,7 +136,7 @@ Zotero.ZotFile.pdfOutline = new function() {
         } else { // we're done
             Zotero.Browser.deleteHiddenBrowser(this.pdfHiddenBrowser);
             this.pdfHiddenBrowser = null;
-            this.progressWin.startCloseTimer(Zotero.ZotFile.prefs.getIntPref("info_window_duration"));
+            this.progressWin.startCloseTimer(Zotero.ZotFile.getPref("info_window_duration"));
         }
     };
 };

--- a/chrome/content/zotfile/pdfextract/extract.js
+++ b/chrome/content/zotfile/pdfextract/extract.js
@@ -24,7 +24,7 @@ Zotero.ZotFile.PdfExtractor = {
         // create Uint8Array from file data
         var int8View = new Uint8Array(array);
         // set options for extractions
-        var removeHyphens = Zotero.ZotFile.prefs.getBoolPref("pdfExtraction.NoteRemoveHyphens");
+        var removeHyphens = Zotero.ZotFile.getPref("pdfExtraction.NoteRemoveHyphens");
         args.itemProgress.setProgress(0);
         var progress = function(x, y) {
           args.itemProgress.setProgress(x*100/y);

--- a/chrome/content/zotfile/pdfextract/pdfjs/src/shared/fonts_utils.js
+++ b/chrome/content/zotfile/pdfextract/pdfjs/src/shared/fonts_utils.js
@@ -418,7 +418,7 @@ function writeToFile(aBytes, aFilePath) {
   netscape.security.PrivilegeManager.enablePrivilege('UniversalXPConnect');
   var Cc = Components.classes,
       Ci = Components.interfaces;
-  var file = Cc['@mozilla.org/file/local;1'].createInstance(Ci.nsILocalFile);
+  var file = Cc['@mozilla.org/file/local;1'].createInstance(Ci.nsIFile);
   file.initWithPath(aFilePath);
 
   var stream = Cc['@mozilla.org/network/file-output-stream;1']

--- a/chrome/content/zotfile/tablet.js
+++ b/chrome/content/zotfile/tablet.js
@@ -374,20 +374,20 @@ Zotero.ZotFile.Tablet = new function() {
             .some(c => c.condition == 'tag' && c.operator != 'isNot' && c.value.indexOf(this.tag) !== -1)
         var searches = Zotero.Searches.getAll().filter(search_filter);
         // remove all note related conditions
-        searches.forEach(function(search) {
+        for (let search of searches) {
             search.getConditions()
                 .filter(c => c.condition == 'note' && c.operator == 'contains')
                 .forEach(c => search.removeCondition(c.id))
             yield search.saveTx();
-        });
+        }
         // restrict to subfolder or unfiled items (basefolder)
         var note_contains = which > 0 ? subfolders[which - 1].path : '&quot;projectFolder&quot;:&quot;&quot;';
-        searches.forEach(function(search) {
+        for (let search of searches) {
             search.addCondition('note', 'contains', note_contains);
             yield search.saveTx();
             var win = this.wm.getMostRecentWindow('navigator:browser');
             win.ZoteroPane.onCollectionSelected();
-        });
+        }
     }.bind(Zotero.ZotFile));
 
 

--- a/chrome/content/zotfile/wildcards.js
+++ b/chrome/content/zotfile/wildcards.js
@@ -47,21 +47,21 @@ Zotero.ZotFile.Wildcards = new function() {
         title = '' + title
 
         // truncate title after : . and ?
-        if(Zotero.ZotFile.prefs.getBoolPref("truncate_title")) {
+        if(Zotero.ZotFile.getPref("truncate_title")) {
             var truncate = title.search(/:|\.|\?|\!/);
             if(truncate!=-1) title = title.substr(0,truncate);
         }
 
         // truncate if to long
-        if (title.length > Zotero.ZotFile.prefs.getIntPref("max_titlelength")) {
-            var max_titlelength=Zotero.ZotFile.prefs.getIntPref("max_titlelength");
+        if (title.length > Zotero.ZotFile.getPref("max_titlelength")) {
+            var max_titlelength=Zotero.ZotFile.getPref("max_titlelength");
             var before_trunc_char = title.substr(max_titlelength,1);
 
             // truncate title at max length
             title = title.substr(0,max_titlelength);
 
             // remove the last word until a space is found
-            if(Zotero.ZotFile.prefs.getBoolPref("truncate_smart") && title.search(" ")!=-1 && before_trunc_char.search(/[a-zA-Z0-9]/!=-1)) {
+            if(Zotero.ZotFile.getPref("truncate_smart") && title.search(" ")!=-1 && before_trunc_char.search(/[a-zA-Z0-9]/!=-1)) {
                 while (title.substring(title.length-1, title.length) != ' ') title = title.substring(0, title.length-1);
                 title = title.substring(0, title.length-1);
             }
@@ -124,17 +124,17 @@ Zotero.ZotFile.Wildcards = new function() {
         else if (item_type === 32) creatorType = [21];
         else if (item_type === 27) creatorType = [24];
         else if (item_type === 16) creatorType = [12];
-        var add_etal = Zotero.ZotFile.prefs.getBoolPref("add_etal");
+        var add_etal = Zotero.ZotFile.getPref("add_etal");
         var author = "", author_lastf="", author_initials="", author_lastg = "";
         var creators = item.getCreators();
         var numauthors = creators.length;
         for (var i = 0; i < creators.length; ++i) {
             if (creatorType.indexOf(creators[i].creatorTypeID) === -1) numauthors=numauthors-1;
         }
-        var max_authors = (Zotero.ZotFile.prefs.getBoolPref("truncate_authors")) ? Zotero.ZotFile.prefs.getIntPref("max_authors") : 500;
+        var max_authors = (Zotero.ZotFile.getPref("truncate_authors")) ? Zotero.ZotFile.getPref("max_authors") : 500;
         if (numauthors <= max_authors) add_etal = false;
-        else numauthors = Zotero.ZotFile.prefs.getIntPref("number_truncate_authors");
-        var delimiter = Zotero.ZotFile.prefs.getCharPref("authors_delimiter");
+        else numauthors = Zotero.ZotFile.getPref("number_truncate_authors");
+        var delimiter = Zotero.ZotFile.getPref("authors_delimiter");
         var j = 0;
         for (i = 0; i < creators.length; ++i) {
             if (j < numauthors && creatorType.indexOf(creators[i].creatorTypeID) != -1) {
@@ -153,10 +153,10 @@ Zotero.ZotFile.Wildcards = new function() {
             }
         }
         if (add_etal) {
-            author = author + Zotero.ZotFile.prefs.getCharPref("etal");
-            author_lastf = author_lastf + Zotero.ZotFile.prefs.getCharPref("etal");
-            author_initials = author_initials + Zotero.ZotFile.prefs.getCharPref("etal");
-            author_lastg = author_lastg + Zotero.ZotFile.prefs.getCharPref("etal");
+            author = author + Zotero.ZotFile.getPref("etal");
+            author_lastf = author_lastf + Zotero.ZotFile.getPref("etal");
+            author_initials = author_initials + Zotero.ZotFile.getPref("etal");
+            author_lastg = author_lastg + Zotero.ZotFile.getPref("etal");
         }
         //create last (senior) author string
         var lastAuthor = "", lastAuthor_lastf= "", lastAuthor_initials= "", lastAuthor_lastInitial = "";
@@ -174,7 +174,7 @@ Zotero.ZotFile.Wildcards = new function() {
             if (editorType.indexOf(creators[i].creatorTypeID) === -1) numeditors=numeditors-1;
         }
         if (numeditors <= max_authors) add_etal = false;
-        else numeditors = Zotero.ZotFile.prefs.getIntPref("number_truncate_authors");
+        else numeditors = Zotero.ZotFile.getPref("number_truncate_authors");
         var j = 0;
         for (i = 0; i < creators.length; ++i) {
             if (j < numeditors && editorType.indexOf(creators[i].creatorTypeID) != -1) {
@@ -266,8 +266,8 @@ Zotero.ZotFile.Wildcards = new function() {
             return output;
         };
         // get wildcards object from preferences
-        var wildcards = JSON.parse(Zotero.ZotFile.prefs.getCharPref("wildcards.default"));
-        var wildcards_user = JSON.parse(Zotero.ZotFile.prefs.getCharPref("wildcards.user"));
+        var wildcards = JSON.parse(Zotero.ZotFile.getPref("wildcards.default"));
+        var wildcards_user = JSON.parse(Zotero.ZotFile.getPref("wildcards.user"));
         for (var key in wildcards_user) { wildcards[key] = wildcards_user[key]; }
         // define wildcard table for item by iterating through wildcards
         var table = {};


### PR DESCRIPTION
I made a bunch of changes necessary for compatibility with the upcoming Firefox 60 ESR base. See https://groups.google.com/d/topic/zotero-dev/a1IPUJ2m_3s/discussion for more details.

Note that the Windows `dev` builds aren't currently working, so this needs to tested on macOS or Linux.

I don't know how to test most of this, so these changes were largely blind, and there may be other issues I missed, but basic loading and renaming now appears to be working.