### PR TITLE
Always use Services.wm for nsIWindowMediator

### DIFF
--- a/chrome/content/zotfile/options.js
+++ b/chrome/content/zotfile/options.js
@@ -115,7 +115,7 @@ var updatePreferenceWindow = function (which) {
 var checkRenameFormat = function(which) {
     try {
         // get current item
-        var win = this.wm.getMostRecentWindow("navigator:browser");
+        var win = Services.wm.getMostRecentWindow("navigator:browser");
         var items = win.ZoteroPane.getSelectedItems();
         var item = items.length > 0 ? items[0] : Zotero.Items.get(1);
         // get renaming rules
@@ -240,7 +240,7 @@ var checkFolderLocation = Zotero.Promise.coroutine(function* (folder) {
 var previewFilename = function() {
     try {
         // get current item
-        var win = this.wm.getMostRecentWindow("navigator:browser");
+        var win = Services.wm.getMostRecentWindow("navigator:browser");
         var items = win.ZoteroPane.getSelectedItems();
         var item = items[0];
         // get renaming rules

--- a/chrome/content/zotfile/pdfOutline.js
+++ b/chrome/content/zotfile/pdfOutline.js
@@ -66,7 +66,7 @@ Zotero.ZotFile.pdfOutline = new function() {
             return;
         }            
         // create toc from outline
-        var win = zz.wm.getMostRecentWindow("navigator:browser"),
+        var win = Services.wm.getMostRecentWindow("navigator:browser"),
             toc = win.document.createElementNS(zz.xhtml, 'ul'),
             key = att.key,
             lib = att.library.libraryType == 'user' ? 0 : att.libraryID,

--- a/chrome/content/zotfile/tablet.js
+++ b/chrome/content/zotfile/tablet.js
@@ -163,7 +163,7 @@ Zotero.ZotFile.Tablet = new function() {
      */
     this.addInfo = function(att, data) {
         // get current content of note
-        var win = this.wm.getMostRecentWindow('navigator:browser'),
+        var win = Services.wm.getMostRecentWindow('navigator:browser'),
             parser = Components.classes["@mozilla.org/xmlextras/domparser;1"]
                         .createInstance(Components.interfaces.nsIDOMParser),
             content = att.getNote().replace(/zotero:\/\//g, 'http://zotfile.com/'),
@@ -218,7 +218,7 @@ Zotero.ZotFile.Tablet = new function() {
      * @yield {void}
      */
     this.showTabletFile = Zotero.Promise.coroutine(function* () {
-        var win = this.wm.getMostRecentWindow("navigator:browser"),
+        var win = Services.wm.getMostRecentWindow("navigator:browser"),
             att = win.ZoteroPane.getSelectedItems()[0],
             tablet = this.Tablet.getTabletStatus(att);
         if (!tablet) return;
@@ -231,7 +231,7 @@ Zotero.ZotFile.Tablet = new function() {
      * @yield {void}
      */
     this.openTabletFile = Zotero.Promise.coroutine(function* () {
-        var win = this.wm.getMostRecentWindow("navigator:browser"),
+        var win = Services.wm.getMostRecentWindow("navigator:browser"),
             att = win.ZoteroPane.getSelectedItems()[0],
             tablet = this.Tablet.getTabletStatus(att);
         if (!tablet) return;
@@ -338,7 +338,7 @@ Zotero.ZotFile.Tablet = new function() {
 
     this.checkSelectedSearch = function() {
         // get selected saved search
-        var win = this.wm.getMostRecentWindow('navigator:browser'),
+        var win = Services.wm.getMostRecentWindow('navigator:browser'),
             search = win.ZoteroPane.getSelectedSavedSearch();
         // returns false if no saved search is selected (e.g. collection)
         if (!search) return false;
@@ -367,7 +367,7 @@ Zotero.ZotFile.Tablet = new function() {
     }.bind(Zotero.ZotFile));
 
     this.restrictTabletSearch = Zotero.Promise.coroutine(function* (which) {
-        var win = this.wm.getMostRecentWindow("navigator:browser"),
+        var win = Services.wm.getMostRecentWindow("navigator:browser"),
             subfolders = JSON.parse(this.getPref("tablet.subfolders"));
         // get tablet searches
         var search_filter = s => s.getConditions()
@@ -385,7 +385,7 @@ Zotero.ZotFile.Tablet = new function() {
         for (let search of searches) {
             search.addCondition('note', 'contains', note_contains);
             yield search.saveTx();
-            var win = this.wm.getMostRecentWindow('navigator:browser');
+            var win = Services.wm.getMostRecentWindow('navigator:browser');
             win.ZoteroPane.onCollectionSelected();
         }
     }.bind(Zotero.ZotFile));

--- a/chrome/content/zotfile/ui.js
+++ b/chrome/content/zotfile/ui.js
@@ -11,7 +11,7 @@ Zotero.ZotFile.UI = new function() {
      */
     this.showCollectionMenu = function() {
         // ZoteroPane object
-        var doc = this.wm.getMostRecentWindow("navigator:browser").ZoteroPane.document;
+        var doc = Services.wm.getMostRecentWindow("navigator:browser").ZoteroPane.document;
         // check regular item or attachment selected & custom subfolders
         var collection_menu = this.getPref("tablet") && this.Tablet.checkSelectedSearch() && this.getPref("tablet.projectFolders") == 2;
         // show or hide zotfile menu items
@@ -21,7 +21,7 @@ Zotero.ZotFile.UI = new function() {
     }.bind(Zotero.ZotFile);
 
     this.buildZotFileCollectionMenu = function() {
-        var win = this.wm.getMostRecentWindow('navigator:browser'),
+        var win = Services.wm.getMostRecentWindow('navigator:browser'),
             nodes = win.ZoteroPane.document.getElementById('id-zotfile-collection-menu').childNodes;
         // hide all items by default
         for (i = 0; i < nodes.length; i++) nodes[i].setAttribute('hidden', true);
@@ -43,7 +43,7 @@ Zotero.ZotFile.UI = new function() {
 
     this.showMenu = function() {
         // get selected items
-        var pane = this.wm.getMostRecentWindow("navigator:browser").ZoteroPane,
+        var pane = Services.wm.getMostRecentWindow("navigator:browser").ZoteroPane,
             items = pane.getSelectedItems();
         // check regular item or attachment selected
         var show_menu = items.some(item => item.isAttachment() || item.isRegularItem());
@@ -55,7 +55,7 @@ Zotero.ZotFile.UI = new function() {
 
     this.buildZotFileMenu = Zotero.Promise.coroutine(function* () {
         // get selected items
-        var win = this.wm.getMostRecentWindow("navigator:browser"),
+        var win = Services.wm.getMostRecentWindow("navigator:browser"),
             items = win.ZoteroPane.getSelectedItems();
         // get menu and recreate structure of child items
         var menu = win.ZoteroPane.document.getElementById('id-zotfile-menu');
@@ -200,7 +200,7 @@ Zotero.ZotFile.UI = new function() {
 
     this.buildTabletMenu = function() {
         // get selected items
-        var pane = this.wm.getMostRecentWindow("navigator:browser").ZoteroPane,
+        var pane = Services.wm.getMostRecentWindow("navigator:browser").ZoteroPane,
             att = pane.getSelectedItems()[0],
             tablet = this.Tablet.getTabletStatus(att);
         if (!att.isAttachment()) return;        
@@ -288,7 +288,7 @@ Zotero.ZotFile.UI = new function() {
 
     this.attboxAddTabletRow = function() {
         // add tablet row to attachment info
-        var pane = Zotero.ZotFile.wm.getMostRecentWindow("navigator:browser").ZoteroPane,
+        var pane = Services.wm.getMostRecentWindow("navigator:browser").ZoteroPane,
             row = pane.document.createElement("row");
         row.setAttribute('id', 'zotfile-tablet-row');
         var rows = pane.document.getElementById('indexStatusRow').parentNode,
@@ -314,7 +314,7 @@ Zotero.ZotFile.UI = new function() {
     }.bind(Zotero.ZotFile);
 
     this.attboxUpdateTabletStatus = function() {
-        var pane = this.wm.getMostRecentWindow('navigator:browser').ZoteroPane,
+        var pane = Services.wm.getMostRecentWindow('navigator:browser').ZoteroPane,
             items = pane.getSelectedItems(),
             row = pane.document.getElementById('zotfile-tablet-row');
         if (items.length != 1) return;

--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -21,7 +21,6 @@ http://www.zotero.org/support/dev/client_coding/javascript_api
 
 
 Zotero.ZotFile = new function() {
-    this.wm = null;
     this.folderSep = null;
     this.projectNr = new Array('01','02','03','04','05','06','07','08','09','10','11','12','13','14','15');
     this.projectPath = new Array('','','','','','','','','','','','','','','');
@@ -67,7 +66,6 @@ Zotero.ZotFile = new function() {
         // only do this stuff for the first run
         if (!_initialized) {
             // defined zotfile variables
-            this.wm = Services.wm;
             this.ffPrefs = Components.classes["@mozilla.org/preferences-service;1"]
                 .getService(Components.interfaces.nsIPrefService).getBranch("browser.download.");
             this.Tablet.tag = this.getPref("tablet.tag");
@@ -118,7 +116,7 @@ Zotero.ZotFile = new function() {
             .loadSubScript("chrome://zotfile/content/ProgressWindow.js", Zotero.ZotFile);
         // add event listener for selecting items in zotero tree
         if(this.getPref('tablet')) {
-            var pane = this.wm.getMostRecentWindow("navigator:browser").ZoteroPane,
+            var pane = Services.wm.getMostRecentWindow("navigator:browser").ZoteroPane,
                 tree = pane.document.getElementById('zotero-items-tree');
             tree.removeEventListener('select', Zotero.ZotFile.UI.attboxUpdateTabletStatus);
             tree.addEventListener('select', Zotero.ZotFile.UI.attboxUpdateTabletStatus);
@@ -185,7 +183,7 @@ Zotero.ZotFile = new function() {
     this.getSelectedAttachments = function (all) {
         all = typeof all !== 'undefined' ? all : false;
         // get selected items
-        var win = this.wm.getMostRecentWindow("navigator:browser");
+        var win = Services.wm.getMostRecentWindow("navigator:browser");
         var attachments = win.ZoteroPane.getSelectedItems()
             .map(item => item.isRegularItem() ? item.getAttachments() : item)
             .reduce((a, b) => a.concat(b), [])
@@ -831,7 +829,7 @@ Zotero.ZotFile = new function() {
      */
     this.attachFileFromSourceDirectory = Zotero.Promise.coroutine(function* () {
         // get selected items
-        var win = this.wm.getMostRecentWindow("navigator:browser"),
+        var win = Services.wm.getMostRecentWindow("navigator:browser"),
             item = win.ZoteroPane.getSelectedItems()[0];
         // if not top-level item, get parent
         item = !item.isTopLevelItem() ? Zotero.Items.get(item.parentItemID) : item;
@@ -891,7 +889,7 @@ Zotero.ZotFile = new function() {
         if (!att.isAttachment()) throw('Zotero.ZotFile.renameAttachment(): No attachment item.');
         if (att.isTopLevelItem()) throw('Zotero.ZotFile.renameAttachment(): Attachment is top-level item.');
         // set variables
-        var win = this.wm.getMostRecentWindow("navigator:browser"),
+        var win = Services.wm.getMostRecentWindow("navigator:browser"),
             selection = win.ZoteroPane.itemsView.saveSelection(),
             att_id = att.id,
             linkmode = att.attachmentLinkMode,


### PR DESCRIPTION
No need to assign it to `Zotero.ZotFile.wm`, and after f1ef7cbbef6 an
error was being thrown if you right-clicked on an item before `init()`
finished waiting for `schemaUpdatePromise`.

There are probably other things in `init()` that need to finish before
various operations will work, so the context-menu options should
probably be disabled until `schemaUpdatePromise` is done.