### PR TITLE
Don't use hardcoded itemTypeIDs and creatorTypeIDs

### DIFF
--- a/chrome/content/zotfile/wildcards.js
+++ b/chrome/content/zotfile/wildcards.js
@@ -115,21 +115,24 @@ Zotero.ZotFile.Wildcards = new function() {
     }
 
     function formatAuthors(item) {
-        var item_type = item.itemTypeID;
         // get creator and create authors string
-        // creator types: author/editor(1,3) for book(2), inventor(14) for patent(19),programmer(24) for computer prog.(27),presenter(21) for presentation(32)
-        var creatorType = [1];
-        if (item_type === 2)  creatorType = [1, 3];
-        else if (item_type === 19) creatorType = [14];
-        else if (item_type === 32) creatorType = [21];
-        else if (item_type === 27) creatorType = [24];
-        else if (item_type === 16) creatorType = [12];
+        var itemType = Zotero.ItemTypes.getName(item.itemTypeID);
+        var creatorTypeIDs;
+        if (itemType == 'book') {
+        	creatorTypeIDs = [
+				Zotero.CreatorTypes.getID('author'),
+				Zotero.CreatorTypes.getID('editor')
+			];
+		}
+        else {
+        	creatorTypeIDs = [Zotero.CreatorTypes.getPrimaryIDForType(item.itemTypeID)];
+        }
         var add_etal = Zotero.ZotFile.getPref("add_etal");
         var author = "", author_lastf="", author_initials="", author_lastg = "";
         var creators = item.getCreators();
         var numauthors = creators.length;
         for (var i = 0; i < creators.length; ++i) {
-            if (creatorType.indexOf(creators[i].creatorTypeID) === -1) numauthors=numauthors-1;
+            if (creatorTypeIDs.indexOf(creators[i].creatorTypeID) === -1) numauthors=numauthors-1;
         }
         var max_authors = (Zotero.ZotFile.getPref("truncate_authors")) ? Zotero.ZotFile.getPref("max_authors") : 500;
         if (numauthors <= max_authors) add_etal = false;
@@ -137,7 +140,7 @@ Zotero.ZotFile.Wildcards = new function() {
         var delimiter = Zotero.ZotFile.getPref("authors_delimiter");
         var j = 0;
         for (i = 0; i < creators.length; ++i) {
-            if (j < numauthors && creatorType.indexOf(creators[i].creatorTypeID) != -1) {
+            if (j < numauthors && creatorTypeIDs.indexOf(creators[i].creatorTypeID) != -1) {
                 if (author !== "") author += delimiter + creators[i].lastName;
                 if (author === "") author = creators[i].lastName;
                 var lastf =  creators[i].lastName + creators[i].firstName.substr(0, 1).toUpperCase();

--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -408,7 +408,9 @@ Zotero.ZotFile = new function() {
         // rename format
         var filename = '',
             item_type =  item.itemTypeID,
-            format_default = item_type == 19 ? this.getPref("renameFormat_patent") : this.getPref("renameFormat");
+            format_default = item_type == Zotero.ItemTypes.getID('patent')
+            	? this.getPref("renameFormat_patent")
+            	: this.getPref("renameFormat");
         format = typeof format !== 'undefined' ? format : format_default;
         // create the new filename from the selected item
         if (!this.getPref('useZoteroToRename')) {


### PR DESCRIPTION
Necessary after zotero/zotero@4b60c6ca2

Also use `Zotero.CreatorTypes.getPrimaryIDForType()` to expand mapping of primary creator types, which I assume is the desired behavior.

Hopefully I didn't miss any other hardcoded ids.