### PR TITLE
Fix various errors

### DIFF
--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -898,7 +898,7 @@ Zotero.ZotFile = new function() {
             item = Zotero.Items.get(att.parentItemID),
             path = yield att.getFilePathAsync(),
             att_note = att.getNote(),
-            att_tags = att.getTags().map(tag => tag.tag),
+            att_tags = att.getTags(),
             att_relations = att.getRelations();
         if (!path) throw('Zotero.ZotFile.renameAttachment(): Attachment file does not exists.'); 
         // only proceed if linked or imported attachment
@@ -919,7 +919,7 @@ Zotero.ZotFile = new function() {
             // restore attachment data
             attNew.setRelations(att_relations);
             if(att_note != '') attNew.setNote(att_note);
-            if(att_tags.length > 0) att_tags.forEach(tag => attNew.addTag(tag));
+            if (att_tags.length) attNew.setTags(att_tags);
             yield attNew.saveTx();
             // select new attachment
             if (selection.includes(att.id)) {
@@ -965,7 +965,7 @@ Zotero.ZotFile = new function() {
             // restore attachment data
             attNew.setRelations(att_relations);
             if(att_note != '') attNew.setNote(att_note);
-            if(att_tags.length > 0) attNew.addTags(att_tags);
+            if (att_tags.length) attNew.setTags(att_tags);
             yield attNew.saveTx();
             // select new attachment
             if (selection.includes(att.id)) {

--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -583,7 +583,7 @@ Zotero.ZotFile = new function() {
                 throw e;
             });
         // delete empty folders after moving file
-        this.removeEmptyFolders(sourceDir);
+        yield this.removeEmptyFolders(sourceDir);
         // return path to new location
         return destPath;
     });
@@ -668,7 +668,7 @@ Zotero.ZotFile = new function() {
             dest_dir = this.getPref('dest_dir');
         if (source_dir) folders_zotfile.push(source_dir);
         if (dest_dir != '') folders_zotfile.push(dest_dir);
-        folders_zotfile = folders_zotfile.map(OS.Path.normalize);
+        folders_zotfile = folders_zotfile.map(path => OS.Path.normalize(path));
         // Only delete folders if the file is located in any of the base folders
         if (!folders_zotfile.map(dir => folder.path.startsWith(dir)).some(x => x === true)) return;
         // remove the original dir recursively until a non empty folder is found

--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -511,29 +511,12 @@ Zotero.ZotFile = new function() {
                 return true;
             }
             
-            // Update mod time and clear hash so the file syncs
-            // TODO: use an integer counter instead of mod time for change detection
-            // Update mod time first, because it may fail for read-only files on Windows
-            yield OS.File.setDates(origPath, null, null);
             destPath = yield this.moveFile(origPath, destPath);
-            
             yield att.relinkAttachmentFile(destPath);
-            
-            att.attachmentSyncedHash = null;
-            att.attachmentSyncState = "to_upload";
-            yield att.saveTx({ skipAll: true });
-            
             return true;
         }
         catch (e) {
-            // Restore original modification date in case we managed to change it
-            try {
-                OS.File.setDates(origPath, null, origModDate);
-            } catch (e) {
-                Zotero.debug(e, 2);
-            }
-            Zotero.debug(e);
-            Components.utils.reportError(e);
+            Zotero.logError(e);
             return false;
         }
     });


### PR DESCRIPTION
This fixes a number of errors I found in a [report from a user](https://forums.zotero.org/discussion/79724/zotfile-renaming-not-working-for-multiple-attachments).

There've been a lot of reports of ZotFile operations on multiple files failing over the last year or two, and I suspect this will fix most or all of those failures.