### PR TITLE
Aggregate colored highlights in one note

### DIFF
--- a/chrome/content/zotfile/pdfAnnotations.js
+++ b/chrome/content/zotfile/pdfAnnotations.js
@@ -222,6 +222,7 @@ Zotero.ZotFile.pdfAnnotations = new function() {
             format_underline = this.getPref("pdfExtraction.formatAnnotationUnderline"),
             settings_colors = JSON.parse(this.getPref("pdfExtraction.colorCategories")),
             setting_color_notes = this.getPref("pdfExtraction.colorNotes"),
+	    setting_aggregate_color_highlights = this.getPref("pdfExtraction.aggregateColorHighlights"),
             cite = this.getPref("pdfExtraction.NoteFullCite") ? this.Wildcards.replaceWildcard(item, "%a %y:").replace(/_(?!.*_)/," and ").replace(/_/g,", ") : "p. ",
             repl = JSON.parse(this.getPref("pdfExtraction.replacements")),
             reg = repl.map(function(obj) {
@@ -276,6 +277,8 @@ Zotero.ZotFile.pdfAnnotations = new function() {
                 var format_markup = anno.subtype == "Highlight" ? format_highlight : format_underline;
                 for (var k = 0; k < repl.length; k++)
                     anno.markup = anno.markup.replace(reg[k], repl[k].replacement);
+	    	if (anno.subtype == "Highlight" && !setting_color_notes && setting_aggregate_color_highlights)
+		    anno.markup = "<span style='background-color:rgba(" + anno.color.join(',') + ",.25)'><strong>(" + color_category + ")</strong> - " + anno.markup + "</span>";
                 var markup_formated = this.Utils.str_format(format_markup, 
 							    {'content': anno.markup, 'cite': link, 'page': page, 'uri': uri, 'label': anno.title, 
 							     'color': color, 'color_category': color_category_hex, 'color_hex': color_hex, 'color_category_name': color_category,

--- a/chrome/content/zotfile/pdfAnnotations.js
+++ b/chrome/content/zotfile/pdfAnnotations.js
@@ -222,7 +222,7 @@ Zotero.ZotFile.pdfAnnotations = new function() {
             format_underline = this.getPref("pdfExtraction.formatAnnotationUnderline"),
             settings_colors = JSON.parse(this.getPref("pdfExtraction.colorCategories")),
             setting_color_notes = this.getPref("pdfExtraction.colorNotes"),
-	    setting_aggregate_color_highlights = this.getPref("pdfExtraction.aggregateColorHighlights"),
+	    setting_aggregate_color_highlights = this.getPref("pdfExtraction.colorAnnotations"),
             cite = this.getPref("pdfExtraction.NoteFullCite") ? this.Wildcards.replaceWildcard(item, "%a %y:").replace(/_(?!.*_)/," and ").replace(/_/g,", ") : "p. ",
             repl = JSON.parse(this.getPref("pdfExtraction.replacements")),
             reg = repl.map(function(obj) {
@@ -277,7 +277,7 @@ Zotero.ZotFile.pdfAnnotations = new function() {
                 var format_markup = anno.subtype == "Highlight" ? format_highlight : format_underline;
                 for (var k = 0; k < repl.length; k++)
                     anno.markup = anno.markup.replace(reg[k], repl[k].replacement);
-	    	if (anno.subtype == "Highlight" && !setting_color_notes && setting_aggregate_color_highlights)
+	    	if (!setting_color_notes && setting_aggregate_color_highlights)
 		    anno.markup = "<span style='background-color:rgba(" + anno.color.join(',') + ",.25)'><strong>(" + color_category + ")</strong> - " + anno.markup + "</span>";
                 var markup_formated = this.Utils.str_format(format_markup, 
 							    {'content': anno.markup, 'cite': link, 'page': page, 'uri': uri, 'label': anno.title, 

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -128,6 +128,6 @@ pref("extensions.zotfile.pdfExtraction.formatAnnotationUnderline", '<p>"<u>%(con
 pref("extensions.zotfile.pdfExtraction.replacements", '[]');
 pref("extensions.zotfile.pdfExtraction.localeDateInNote", true);
 pref("extensions.zotfile.pdfExtraction.colorNotes", false);
-pref("extensions.zotfile.pdfExtraction.aggregateColorHighlights", false);
+pref("extensions.zotfile.pdfExtraction.colorAnnotations", false);
 pref("extensions.zotfile.pdfExtraction.colorCategories", '{"Black": "#000000", "White": "#FFFFFF", "Gray": "#808080", "Red": "#FF0000", "Orange": "#FFA500", "Yellow": "#FFFF00", "Green": "#00FF00", "Cyan": "#00FFFF", "Blue": "#0000FF", "Magenta": "#FF00FF"}');
 //pref("extensions.zotfile.pdfExtraction.format", '"<p>%(markup)s" %(cite)s</p><br><p>%(note)s</p><br>');


### PR DESCRIPTION
A small feature addition that allows highlights of different colors to be combined in one note (cf. the `extensions.zotfile.pdfExtraction.colorNotes` preference, which separates them into discrete notes). The idea is to maintain the sequence of highlights as they appear in the highlighted document, while also retaining the different highlight colours - I find this more intuitive than piecing together the ordering from multiple notes containing each colour of highlight. Includes the color label (e.g. "(Green)") in case of printing the note in black and white.

The feature can be enabled using the `extensions.zotfile.pdfExtraction.aggregateColorHighlights` preference. Does not conflict with the `colorNotes` preference (it takes precedence).

An example (for me, green highlights are Very Important, red are Important):

<img src="https://user-images.githubusercontent.com/912688/67850552-eca42000-fb08-11e9-95a3-705de5664096.png" data-canonical-src="https://user-images.githubusercontent.com/912688/67850552-eca42000-fb08-11e9-95a3-705de5664096.png" width="200" />