### PR TITLE
Fix cross-platform handling of subfolder paths

### DIFF
--- a/chrome/content/zotfile/tablet.js
+++ b/chrome/content/zotfile/tablet.js
@@ -144,9 +144,9 @@ Zotero.ZotFile.Tablet = new function() {
             }
             // for location tag: replace [BaseFolder] with destination folder
             if(key == 'location') value = value.replace('[BaseFolder]', this.getPref('tablet.dest_dir'));
-            // for location tag: correct window/mac file system
-            if(key == 'location' && Zotero.isWin) value = value.replace(/\//g, '\\');
-            if(key == 'location' && !Zotero.isWin) value = value.replace(/\\/g, '/');
+            // for location and projectFolder tag: correct window/mac file system
+            if(['location', 'projectFolder'].includes(key) && Zotero.isWin) value = value.replace(/\//g, '\\');
+            if(['location', 'projectFolder'].includes(key) && !Zotero.isWin) value = value.replace(/\\/g, '/');
             // return
             return value;
         }


### PR DESCRIPTION
This PR fixes handling of directory separators when storing attachments in subfolders, in order to support migrating between Windows and Mac/Linux.

When an attachment is saved to a subfolder, the 'projectFolder' info values will contain directory separators just like the 'location' values. Directory separators must therefore be updated for 'projectFolder' values in the same way that was already correctly done for the 'location' values.

**Workflow for reproducing earlier incorrect behavior**
(The described steps apply to Zotfile in Background mode.)

1. Move an attachment to a subfolder on the device, using Zotero/Zotfile in Windows.
    1. This makes Zotfile store the following metadata:
`location` contains: `[BaseFolder]\Folder\Subfolder\Filename.pdf`
`projectFolder` contains: `Folder\Subfolder`
2. Change the file on the device
3. Open Zotero/Zotfile in Linux/Mac, and choose `Update File Modification Time` in order to sync the changes.
    1. Zotfile [gets the file from the device](https://github.com/jlegewie/zotfile/blob/master/chrome/content/zotfile/tablet.js#L559), using the `location` key. Here, `\` is automatically converted to `/`, so Zotfile looks in `[BaseFolder]/Folder/Subfolder/Filename.pdf` and successfully finds the file.
    2. Zotfile immediately [sends the file back](https://github.com/jlegewie/zotfile/blob/master/chrome/content/zotfile/tablet.js#L561) to the device, using the `projectFolder` key. Here, `\` is not converted to `/`, so the file now ends up in `[BaseFolder]/Folder\Subfolder/Filename.pdf`. This path is also stored to `location`.
    3. When later trying to read the file from the device, Zotfile uses the `location` key again, but now `\` is converted into `/`, so it looks for the file in `[BaseFolder]/Folder/Subfolder/Filename.pdf` where the file no longer exists, and Zotfile gives an error message about not finding the file.

By automatically translating directory separators in `projectFolder` in addition to `location`, Zotero wil consistently use the correct directory separators, and the above workflow has been confirmed to work properly after applying this PR.