### PR TITLE
Add 'truncateTitle' transformation to user-defined wildcards

### DIFF
--- a/chrome/content/zotfile/wildcards.js
+++ b/chrome/content/zotfile/wildcards.js
@@ -264,6 +264,8 @@ Zotero.ZotFile.Wildcards = new function() {
                         output = output.toUpperCase();
                     if(obj.function=="trim")
                         output = output.trim();
+                    if(obj.function=="truncateTitle")
+                        output = truncateTitle(output);
                 }
             }
             // return


### PR DESCRIPTION
This makes the `truncateTitle` function accessible as a transformation that can be used in user-defined wildcards, along with the currently available `toLowerCase`, `toUpperCase`, and `trim`. Currently, the `truncateTitle` function is used for creating the `titleFormated` field. For a user-defined wildcard that uses the `title` field and a regular expression, it would be nice if one could apply `truncateTitle` afterwards. The proposed changes would, e.g., allow to use this wildcard:

`{"1": {"field": "title", "operations":[{"function": "replace", "regex":"<a>", "replacement":""},{"function": "truncateTitle"}]}}`

Note that one cannot apply the regex in this example on the `titleFormated` field, since `<` and `>` would already be removed. See also issue #455.