### PR TITLE
Implements #477 allowing custom format for colorAnnotations notes

### DIFF
--- a/chrome/content/zotfile/pdfAnnotations.js
+++ b/chrome/content/zotfile/pdfAnnotations.js
@@ -222,7 +222,8 @@ Zotero.ZotFile.pdfAnnotations = new function() {
             format_underline = this.getPref("pdfExtraction.formatAnnotationUnderline"),
             settings_colors = JSON.parse(this.getPref("pdfExtraction.colorCategories")),
             setting_color_notes = this.getPref("pdfExtraction.colorNotes"),
-	    setting_aggregate_color_highlights = this.getPref("pdfExtraction.colorAnnotations"),
+	        setting_aggregate_color_highlights = this.getPref("pdfExtraction.colorAnnotations"),
+	        setting_aggregate_color_highlights_custom_format = this.getPref("pdfExtraction.colorAnnotationsCustomFormat"),
             cite = this.getPref("pdfExtraction.NoteFullCite") ? this.Wildcards.replaceWildcard(item, "%a %y:").replace(/_(?!.*_)/," and ").replace(/_/g,", ") : "p. ",
             repl = JSON.parse(this.getPref("pdfExtraction.replacements")),
             reg = repl.map(function(obj) {
@@ -277,8 +278,12 @@ Zotero.ZotFile.pdfAnnotations = new function() {
                 var format_markup = anno.subtype == "Highlight" ? format_highlight : format_underline;
                 for (var k = 0; k < repl.length; k++)
                     anno.markup = anno.markup.replace(reg[k], repl[k].replacement);
-	    	if (!setting_color_notes && setting_aggregate_color_highlights)
-		    anno.markup = "<span style='background-color:rgba(" + anno.color.join(',') + ",.25)'><strong>(" + color_category + ")</strong> - " + anno.markup + "</span>";
+	    	    if (!setting_color_notes && setting_aggregate_color_highlights) {
+                    var rgbaHighlightColor = anno.color.join(',');
+                    anno.markup = this.Utils.str_format(setting_aggregate_color_highlights_custom_format, {
+                        'rgba_color': rgbaHighlightColor, 'color_category': color_category, 'markup': anno.markup
+                    })
+                }
                 var markup_formated = this.Utils.str_format(format_markup, 
 							    {'content': anno.markup, 'cite': link, 'page': page, 'uri': uri, 'label': anno.title, 
 							     'color': color, 'color_category': color_category_hex, 'color_hex': color_hex, 'color_category_name': color_category,

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -130,6 +130,6 @@ pref("extensions.zotfile.pdfExtraction.replacements", '[]');
 pref("extensions.zotfile.pdfExtraction.localeDateInNote", true);
 pref("extensions.zotfile.pdfExtraction.colorNotes", false);
 pref("extensions.zotfile.pdfExtraction.colorAnnotations", false);
-pref("extensions.zotfile.pdfExtraction.colorAnnotationsCustomFormat", "<span style='background-color:rgba( %(rgba_color),.25)'><strong>#%(color_category)</strong> - %(markup)</span>");
+pref("extensions.zotfile.pdfExtraction.colorAnnotationsCustomFormat", "<span style='background-color:rgba(%(rgba_color),.25)'><strong>(%(color_category))</strong> - %(markup)</span>");
 pref("extensions.zotfile.pdfExtraction.colorCategories", '{"Black": "#000000", "White": "#FFFFFF", "Gray": "#808080", "Red": "#FF0000", "Orange": "#FFA500", "Yellow": "#FFFF00", "Green": "#00FF00", "Cyan": "#00FFFF", "Blue": "#0000FF", "Magenta": "#FF00FF"}');
 //pref("extensions.zotfile.pdfExtraction.format", '"<p>%(markup)s" %(cite)s</p><br><p>%(note)s</p><br>');

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -130,5 +130,6 @@ pref("extensions.zotfile.pdfExtraction.replacements", '[]');
 pref("extensions.zotfile.pdfExtraction.localeDateInNote", true);
 pref("extensions.zotfile.pdfExtraction.colorNotes", false);
 pref("extensions.zotfile.pdfExtraction.colorAnnotations", false);
+pref("extensions.zotfile.pdfExtraction.colorAnnotationsCustomFormat", "<span style='background-color:rgba( %(rgba_color),.25)'><strong>#%(color_category)</strong> - %(markup)</span>");
 pref("extensions.zotfile.pdfExtraction.colorCategories", '{"Black": "#000000", "White": "#FFFFFF", "Gray": "#808080", "Red": "#FF0000", "Orange": "#FFA500", "Yellow": "#FFFF00", "Green": "#00FF00", "Cyan": "#00FFFF", "Blue": "#0000FF", "Magenta": "#FF00FF"}');
 //pref("extensions.zotfile.pdfExtraction.format", '"<p>%(markup)s" %(cite)s</p><br><p>%(note)s</p><br>');


### PR DESCRIPTION
Allows users to specify how colorAnnotations-enabled notes should be formatted, much like the customisations that Zotfile already allows for e.g. note titles.