### PR TITLE
Add ISO date string preference

### DIFF
--- a/chrome/content/zotfile/pdfAnnotations.js
+++ b/chrome/content/zotfile/pdfAnnotations.js
@@ -230,8 +230,24 @@ Zotero.ZotFile.pdfAnnotations = new function() {
                 return new RegExp(obj.regex, flags);
             });
         // add note title
-        var date_str = this.getPref("pdfExtraction.localeDateInNote") ? new Date().toLocaleString() : new Date().toUTCString(),
-            title = this.Utils.str_format(format_title, {'title': str_title, 'date': date_str}),
+        var date_str;
+        if (this.getPref("pdfExtraction.localeDateInNote")){
+            date_str = new Date().toLocaleString();
+            Zotero.debug("locale");
+            Zotero.debug(date_str);
+        }
+        else if (this.getPref("pdfExtraction.isoDate")){
+            date_str = new Date().toISOString().substring(0, 10);
+            Zotero.debug("ISO");
+            Zotero.debug(date_str);
+        }
+        else {
+            date_str = new Date().toUTCString();
+            Zotero.debug("else");
+            Zotero.debug(date_str);
+        }
+
+        var title = this.Utils.str_format(format_title, {'title': str_title, 'date': date_str}),
             note = title;
         if (this.getPref("pdfExtraction.UsePDFJSandPoppler"))
             note += ' ' + method;

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -127,6 +127,7 @@ pref("extensions.zotfile.pdfExtraction.formatAnnotationNote", '<p><i>%(content) 
 pref("extensions.zotfile.pdfExtraction.formatAnnotationHighlight", '<p>"%(content)" (%(cite))</p>');
 pref("extensions.zotfile.pdfExtraction.formatAnnotationUnderline", '<p>"<u>%(content)</u>" (%(cite))</p>');
 pref("extensions.zotfile.pdfExtraction.replacements", '[]');
+pref("extensions.zotfile.pdfExtraction.isoDate", false);
 pref("extensions.zotfile.pdfExtraction.localeDateInNote", true);
 pref("extensions.zotfile.pdfExtraction.colorNotes", false);
 pref("extensions.zotfile.pdfExtraction.colorAnnotations", false);


### PR DESCRIPTION
Since date_str was being used in several places, I opted for the simplest option and switched the ternary operator for an if clause. The new preference needs the user to set `localeDateInNote` to false and `isoDate` to true, so users' have to intentionally modify settings to get an ISO date instead of Zotfile's defaults. 

Closes #480