### PR TITLE
Tablet annotation behavior

### DIFF
--- a/chrome/content/zotfile/options.js
+++ b/chrome/content/zotfile/options.js
@@ -60,7 +60,21 @@ var updatePreferenceWindow = function (which) {
     if(which=="subfolder-tablet" || which=="all") disablePreference("tablet-subfolder", "tablet-subfolderFormat", revert);
     
     // storeCopyOfFile-tablet
-    if(which=="storeCopyOfFile" || which=="all") disablePreference("tablet-storeCopyOfFile", "tablet-storeCopyOfFile_suffix", revert);
+    if(which=="storeCopyOfFile" || which=="all"){
+        disablePreference("tablet-storeCopyOfFile",  "tablet-storeCopyOfFile_suffix", revert);
+    }
+
+    // storeCopyOfFile or tablet-rename 
+    if(which=="storeCopyOfFile" || which=="tablet-rename" || which=="all"){
+        var storecopy = document.getElementById('pref-zotfile-tablet-storeCopyOfFile').value;
+        var rename = document.getElementById('pref-zotfile-tablet-rename').value
+        // the value is the status before clicking
+        if (which == "storeCopyOfFile") storecopy = !storecopy;
+        if (which == "tablet-rename") rename = !rename;
+        // enable keep-one-annotated option when storeCopyOfFile is on but tablet-rename is off
+        var enable_keep_one_annotated = storecopy && !rename;
+        document.getElementById('id-zotfile-tablet-keep-one-annotated').disabled = !enable_keep_one_annotated;
+    }
     
     // batch renaming
     if(which=="confirm" || which=="all") disablePreference("confirmation_batch_ask", "confirmation_batch", revert);

--- a/chrome/content/zotfile/options.xul
+++ b/chrome/content/zotfile/options.xul
@@ -44,6 +44,7 @@
 				<preference id="pref-zotfile-confirmation_batch" name="extensions.zotfile.confirmation_batch" type="int"/>
 				<preference id="pref-zotfile-tablet" name="extensions.zotfile.tablet" type="bool"/>
 				<preference id="pref-zotfile-tablet-rename" name="extensions.zotfile.tablet.rename" type="bool"/>
+				<preference id="pref-zotfile-tablet-keep-one-annotated" name="extensions.zotfile.tablet.keepOneAnnotated" type="bool"/>
 				<preference id="pref-zotfile-tablet-dest_dir" name="extensions.zotfile.tablet.dest_dir" type="string"/>
 				<preference id="pref-zotfile-tablet-storeCopyOfFile" name="extensions.zotfile.tablet.storeCopyOfFile" type="bool"/>
 				<preference id="pref-zotfile-tablet-storeCopyOfFile_suffix" name="extensions.zotfile.tablet.storeCopyOfFile_suffix" type="string"/>
@@ -166,6 +167,7 @@
 						<groupbox>
 							<caption label="&additional-options;"/>
 							<checkbox id="id-zotfile-tablet-rename" label="&rename-when-sent-to-tablet;" preference="pref-zotfile-tablet-rename"/>
+							<checkbox id="id-zotfile-tablet-keep-one-annotated" label="&keep-one-annotated;" preference="pref-zotfile-tablet-keep-one-annotated"/>
 							<hbox style="margin: 0"  align="center">
 								<checkbox id="id-zotfile-tablet-storeCopyOfFile" label="&save-annotated-file;" preference="pref-zotfile-tablet-storeCopyOfFile"  oncommand="updatePreferenceWindow('storeCopyOfFile')"/>
 								<textbox id="id-zotfile-tablet-storeCopyOfFile_suffix" preference="pref-zotfile-tablet-storeCopyOfFile_suffix" width="130"/>

--- a/chrome/content/zotfile/options.xul
+++ b/chrome/content/zotfile/options.xul
@@ -166,13 +166,13 @@
 
 						<groupbox>
 							<caption label="&additional-options;"/>
-							<checkbox id="id-zotfile-tablet-rename" label="&rename-when-sent-to-tablet;" preference="pref-zotfile-tablet-rename"/>
-							<checkbox id="id-zotfile-tablet-keep-one-annotated" label="&keep-one-annotated;" preference="pref-zotfile-tablet-keep-one-annotated"/>
+							<checkbox id="id-zotfile-tablet-rename" label="&rename-when-sent-to-tablet;" preference="pref-zotfile-tablet-rename" oncommand="updatePreferenceWindow('tablet-rename')"/>
 							<hbox style="margin: 0"  align="center">
 								<checkbox id="id-zotfile-tablet-storeCopyOfFile" label="&save-annotated-file;" preference="pref-zotfile-tablet-storeCopyOfFile"  oncommand="updatePreferenceWindow('storeCopyOfFile')"/>
 								<textbox id="id-zotfile-tablet-storeCopyOfFile_suffix" preference="pref-zotfile-tablet-storeCopyOfFile_suffix" width="130"/>
 								<image src="chrome://zotfile/skin/information.png" tooltiptext="&tablet-copy-information;"/>
 							</hbox>
+							<checkbox id="id-zotfile-tablet-keep-one-annotated" label="&keep-one-annotated;" preference="pref-zotfile-tablet-keep-one-annotated"/>
 							<checkbox id="id-zotfile-pdfExtraction-Pull" label="&automatically-extract-annotations;" preference="pref-zotfile-pdfExtraction-Pull"/>
 						</groupbox>
 					</tabpanel>

--- a/chrome/content/zotfile/overlay.xul
+++ b/chrome/content/zotfile/overlay.xul
@@ -20,7 +20,7 @@
 				<menuseparator/>
 				<menuitem label="&warning.label;" disabled="true" style="font-size: 100%; background: none; -moz-appearance: none;"/>								
 				<menuitem id="id-push2reader-00" label="&send-to-tablet;" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet();"/>
-				<menuitem id="id-pushannotation2reader-annotation" label="&send-annotation-to-tablet;" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(true);"/>
+				<menuitem id="id-pushannotation2reader-annotation" label="&send-annotation-to-tablet;" tooltiptext="&send-annotation-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(true);"/>
 				<menuitem label="&update-file-modification-time;" tooltiptext="&sync-attachment-file;" oncommand="Zotero.ZotFile.Tablet.updateSelectedTabletAttachments();"/>	
 				<menuitem label="&get-from-tablet;" tooltiptext="&get-attachment-file-from-tablet;" oncommand="Zotero.ZotFile.Tablet.getSelectedAttachmentsFromTablet();"/>				
 				<menuseparator/>

--- a/chrome/content/zotfile/overlay.xul
+++ b/chrome/content/zotfile/overlay.xul
@@ -20,26 +20,27 @@
 				<menuseparator/>
 				<menuitem label="&warning.label;" disabled="true" style="font-size: 100%; background: none; -moz-appearance: none;"/>								
 				<menuitem id="id-push2reader-00" label="&send-to-tablet;" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet();"/>
+				<menuitem id="id-pushannotation2reader-annotation" label="&send-annotation-to-tablet;" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(true);"/>
 				<menuitem label="&update-file-modification-time;" tooltiptext="&sync-attachment-file;" oncommand="Zotero.ZotFile.Tablet.updateSelectedTabletAttachments();"/>	
 				<menuitem label="&get-from-tablet;" tooltiptext="&get-attachment-file-from-tablet;" oncommand="Zotero.ZotFile.Tablet.getSelectedAttachmentsFromTablet();"/>				
 				<menuseparator/>
 				<menuitem label="&send-to-subfolder-on-tablet;" disabled="true" style="font-size: 80%; background: none; -moz-appearance: none;"/>								
 				<menuitem label="&warning.label;" disabled="true" style="font-size: 100%; background: none; -moz-appearance: none;"/>								
-				<menuitem id="id-push2reader-01" hidden="true" label="menu1" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(0);"/>
-				<menuitem id="id-push2reader-02" hidden="true" label="menu2" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(1);"/>
-				<menuitem id="id-push2reader-03" hidden="true" label="menu3" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(2);"/>
-				<menuitem id="id-push2reader-04" hidden="true" label="menu4" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(3);"/>
-				<menuitem id="id-push2reader-05" hidden="true" label="menu5" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(4);"/>
-				<menuitem id="id-push2reader-06" hidden="true" label="menu6" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(5);"/>
-				<menuitem id="id-push2reader-07" hidden="true" label="menu7" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(6);"/>
-				<menuitem id="id-push2reader-08" hidden="true" label="menu8" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(7);"/>
-				<menuitem id="id-push2reader-09" hidden="true" label="menu9" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(8);"/>
-				<menuitem id="id-push2reader-10" hidden="true" label="menu10" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(9);"/>
-				<menuitem id="id-push2reader-11" hidden="true" label="menu11" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(10);"/>
-				<menuitem id="id-push2reader-12" hidden="true" label="menu12" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(11);"/>
-				<menuitem id="id-push2reader-13" hidden="true" label="menu13" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(12);"/>
-				<menuitem id="id-push2reader-14" hidden="true" label="menu14" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(13);"/>
-				<menuitem id="id-push2reader-15" hidden="true" label="menu15" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(14);"/>
+				<menuitem id="id-push2reader-01" hidden="true" label="menu1" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 0);"/>
+				<menuitem id="id-push2reader-02" hidden="true" label="menu2" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 1);"/>
+				<menuitem id="id-push2reader-03" hidden="true" label="menu3" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 2);"/>
+				<menuitem id="id-push2reader-04" hidden="true" label="menu4" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 3);"/>
+				<menuitem id="id-push2reader-05" hidden="true" label="menu5" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 4);"/>
+				<menuitem id="id-push2reader-06" hidden="true" label="menu6" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 5);"/>
+				<menuitem id="id-push2reader-07" hidden="true" label="menu7" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 6);"/>
+				<menuitem id="id-push2reader-08" hidden="true" label="menu8" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 7);"/>
+				<menuitem id="id-push2reader-09" hidden="true" label="menu9" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 8);"/>
+				<menuitem id="id-push2reader-10" hidden="true" label="menu10" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 9);"/>
+				<menuitem id="id-push2reader-11" hidden="true" label="menu11" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 10);"/>
+				<menuitem id="id-push2reader-12" hidden="true" label="menu12" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 11);"/>
+				<menuitem id="id-push2reader-13" hidden="true" label="menu13" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 12);"/>
+				<menuitem id="id-push2reader-14" hidden="true" label="menu14" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 13);"/>
+				<menuitem id="id-push2reader-15" hidden="true" label="menu15" tooltiptext="&send-attachment-file-to-tablet;" oncommand="Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(false, 14);"/>
 
 				<menuseparator/>								
 				<menuitem id="id-push2reader-configure" label="&change-subfolders;" tooltiptext="&add-and-delete-subfolders;" oncommand="Zotero.ZotFile.openSubfolderWindow();"/>

--- a/chrome/content/zotfile/tablet.js
+++ b/chrome/content/zotfile/tablet.js
@@ -487,7 +487,6 @@ Zotero.ZotFile.Tablet = new function() {
         // only choose the longest `suffix` (A_suffix_suffix > A_suffix > A)
         if (annotation_only) {
             var set = new Set();
-            this.infoWindow("before " + atts.length);
             for (let i = 0; i < atts.length; i++) {
                 var att = atts[i];
                 // parentid.filename
@@ -517,7 +516,6 @@ Zotero.ZotFile.Tablet = new function() {
                     i++;
                 }
             }
-            this.infoWindow("after " + atts.length);
         }
         // confirm
         var atts_tablet = yield Zotero.Promise.filter(atts, att =>

--- a/chrome/content/zotfile/ui.js
+++ b/chrome/content/zotfile/ui.js
@@ -126,6 +126,7 @@ Zotero.ZotFile.UI = new function() {
                     show.push(m.push2reader, m.pushannotation2reader, m.pullreader);
                     // set tooltip for base folder
                     menu.childNodes[m.push2reader].setAttribute('tooltiptext', this.ZFgetString('menu.sendAttToBaseFolder', [this.getPref('tablet.dest_dir')]));
+                    menu.childNodes[m.pushannotation2reader].setAttribute('tooltiptext', this.ZFgetString('menu.sendAnnToBaseFolder', [this.getPref('tablet.dest_dir')]));
                     if(!menu_tablet) disable.push(m.pullreader);
                     // add update menu item
                     if(this.Tablet.checkSelectedSearch() || this.getPref('tablet.updateAlwaysShow')) {

--- a/chrome/content/zotfile/ui.js
+++ b/chrome/content/zotfile/ui.js
@@ -67,15 +67,16 @@ Zotero.ZotFile.UI = new function() {
             sep1: 4,
             warning2: 5,
             push2reader: 6,
-            updatefile: 7,
-            pullreader: 8,
-            sep2: 9,
-            tablet: 10,
-            warning3: 11,
-            subfolders: new Array(12,13,14,15,16,17,18,19,20,21,22,23,24,25,26),
-            sep3: 27,
-            menuConfigure: 28,
-            length:29
+            pushannotation2reader: 7,
+            updatefile: 8,
+            pullreader: 9,
+            sep2: 10,
+            tablet: 11,
+            warning3: 12,
+            subfolders: new Array(13,14,15,16,17,18,19,20,21,22,23,24,25,26,27),
+            sep3: 28,
+            menuConfigure: 29,
+            length:30
         };
         // list of disabled and show menu-items
         var disable = [m.tablet, m.warning1, m.warning2, m.warning3], show = [];
@@ -122,7 +123,7 @@ Zotero.ZotFile.UI = new function() {
                     menu.childNodes[m.warning2].setAttribute('label',this.ZFgetString('menu.itemIsInGroupLibrary'));
                 }
                 if(valid_destination && !group_library) {
-                    show.push(m.push2reader, m.pullreader);
+                    show.push(m.push2reader, m.pushannotation2reader, m.pullreader);
                     // set tooltip for base folder
                     menu.childNodes[m.push2reader].setAttribute('tooltiptext', this.ZFgetString('menu.sendAttToBaseFolder', [this.getPref('tablet.dest_dir')]));
                     if(!menu_tablet) disable.push(m.pullreader);
@@ -234,6 +235,15 @@ Zotero.ZotFile.UI = new function() {
                 'disabled': tablet ? 'true' : 'false'
             },
             {
+                'label': 'Send Annotation to Tablet',
+                'tooltiptext': '',
+                'command': function(e) {
+                    Zotero.ZotFile.Tablet.sendSelectedAttachmentsToTablet(true);
+                    Zotero.ZotFile.UI.buildTabletMenu();
+                },
+                'disabled': tablet ? 'true' : 'false'
+            },
+            {
                 'label': 'Get from Tablet',
                 'tooltiptext': '',
                 'command': function(e) {
@@ -271,7 +281,7 @@ Zotero.ZotFile.UI = new function() {
                 var menuitem = pane.document.createElement('menuitem');
                 menuitem.setAttribute('label', folder.label);
                 menuitem.addEventListener('command', function(event) {
-                    this.Tablet.sendSelectedAttachmentsToTablet(i);
+                    this.Tablet.sendSelectedAttachmentsToTablet(false, i);
                     this.UI.buildTabletMenu();
                 });
                 menupopup.appendChild(menuitem);

--- a/chrome/locale/de-DE/options.dtd
+++ b/chrome/locale/de-DE/options.dtd
@@ -34,6 +34,7 @@
 <!ENTITY additional-subfolders "Zusätzliche Unterordner basieren auf den Metadaten von Objekten in Zotero. Verwenden Sie &#37;a für den Namen des Autors, &#37;y für das Jahr, &#37;w für die Zeitschrift bzw. den Herausgeber oder &#37;T für die Art des Eintrags (siehe Zotero Internetseite für eine vollständige Liste). Stellen Sie sicher, dass Sie die richtigen Separatoren verwenden (/ für Mac OS X und andere Unix-Systeme oder \ für Windows).">
 <!ENTITY additional-options "Weitere Optionen">
 <!ENTITY rename-when-sent-to-tablet "Dateien umbennen, wenn sie auf den Tablet PC übertragen umbennen">
+<!ENTITY keep-one-annotated "Keep only one annotated file (detected by suffix)">
 <!ENTITY save-annotated-file "Kopie von annotierten Dateien mit folgendem Suffix speichern:  ">
 <!ENTITY tablet-copy-information "Als Voreinstellung wird beim Holen einer Datei vom Tablet die in Zotero gespeicherte Datei ersetzt. Falls diese Option aktiviert ist, erzeugt zotfile stattdessen eine Kopie der Datei mit dem angegebenen Suffix und fügt diese Datei als zusätzlichen Anhang zu Zotero hinzu.">
 <!ENTITY automatically-extract-annotations "Annotationen automatisch herauskopieren wenn PDF-Dateien vom Tablet PC zurück übertragen werden">

--- a/chrome/locale/de-DE/options.dtd
+++ b/chrome/locale/de-DE/options.dtd
@@ -34,7 +34,7 @@
 <!ENTITY additional-subfolders "Zusätzliche Unterordner basieren auf den Metadaten von Objekten in Zotero. Verwenden Sie &#37;a für den Namen des Autors, &#37;y für das Jahr, &#37;w für die Zeitschrift bzw. den Herausgeber oder &#37;T für die Art des Eintrags (siehe Zotero Internetseite für eine vollständige Liste). Stellen Sie sicher, dass Sie die richtigen Separatoren verwenden (/ für Mac OS X und andere Unix-Systeme oder \ für Windows).">
 <!ENTITY additional-options "Weitere Optionen">
 <!ENTITY rename-when-sent-to-tablet "Dateien umbennen, wenn sie auf den Tablet PC übertragen umbennen">
-<!ENTITY keep-one-annotated "Keep only one annotated file (detected by suffix)">
+<!ENTITY keep-one-annotated "Behalten Sie nur eine kommentierte Datei (erkannt durch Suffix)">
 <!ENTITY save-annotated-file "Kopie von annotierten Dateien mit folgendem Suffix speichern:  ">
 <!ENTITY tablet-copy-information "Als Voreinstellung wird beim Holen einer Datei vom Tablet die in Zotero gespeicherte Datei ersetzt. Falls diese Option aktiviert ist, erzeugt zotfile stattdessen eine Kopie der Datei mit dem angegebenen Suffix und fügt diese Datei als zusätzlichen Anhang zu Zotero hinzu.">
 <!ENTITY automatically-extract-annotations "Annotationen automatisch herauskopieren wenn PDF-Dateien vom Tablet PC zurück übertragen werden">

--- a/chrome/locale/de-DE/overlay.dtd
+++ b/chrome/locale/de-DE/overlay.dtd
@@ -9,6 +9,7 @@
 <!ENTITY pdf-outline.label "Inhaltsverzeichnis herauskopieren">
 <!ENTITY pdf-outline.tooltiptext "Inhaltsverzeichnis aus PDF Datei herauskopieren">
 <!ENTITY send-to-tablet "An Tablet PC schicken">
+<!ENTITY send-annotation-to-tablet "Send Annotation to Tablet">
 <!ENTITY send-attachment-file-to-tablet "Angehängte Datei an Tablet PC schicken.">
 <!ENTITY update-file-modification-time "Datei Zeit der letzten Änderung aktualisieren">
 <!ENTITY sync-attachment-file "Angehängte Datei auf dem Tablet mit jener in Zotero synchronisieren.">

--- a/chrome/locale/de-DE/overlay.dtd
+++ b/chrome/locale/de-DE/overlay.dtd
@@ -9,8 +9,9 @@
 <!ENTITY pdf-outline.label "Inhaltsverzeichnis herauskopieren">
 <!ENTITY pdf-outline.tooltiptext "Inhaltsverzeichnis aus PDF Datei herauskopieren">
 <!ENTITY send-to-tablet "An Tablet PC schicken">
-<!ENTITY send-annotation-to-tablet "Send Annotation to Tablet">
 <!ENTITY send-attachment-file-to-tablet "Angehängte Datei an Tablet PC schicken.">
+<!ENTITY send-annotation-to-tablet "Anmerkung an Tablet senden.">
+<!ENTITY send-annotation-file-to-tablet "Anmerkungsdatei an Tablet senden.">
 <!ENTITY update-file-modification-time "Datei Zeit der letzten Änderung aktualisieren">
 <!ENTITY sync-attachment-file "Angehängte Datei auf dem Tablet mit jener in Zotero synchronisieren.">
 <!ENTITY get-from-tablet "Vom Tablet holen">

--- a/chrome/locale/de-DE/zotfile.properties
+++ b/chrome/locale/de-DE/zotfile.properties
@@ -27,6 +27,7 @@ menu.invalidTabletLocation				=	Speicherort für Dateien auf dem Tablet PC ist n
 menu.itemIsInGroupLibrary				=	Ausgewählte Objekte sind in einer Gruppenbibliothek.
 menu.sendAttToBaseFolder				=	Schicke Datei nach '%S'
 menu.sendAttToSubfolder					=	Schicke Datei nach '...%S'
+menu.sendAnnToBaseFolder				=	Anmerkungsdatei senden an '%S'
 menu.itemIsInNoCollection				=	Objekt ist in keiner Sammlung.
 menu.noSubfoldersDefined				=	Keine Unterordner definiert.
 menu.collection.tooltip                 =   Zeige Objekte in '%S'

--- a/chrome/locale/en-US/options.dtd
+++ b/chrome/locale/en-US/options.dtd
@@ -34,6 +34,7 @@
 <!ENTITY additional-subfolders "Additional subfolders are based on metadata from Zotero items. Use &#37;a for author name, &#37;y for year, &#37;w for journal/publisher, or &#37;T for item type (see the zotfile website for a full list). Make sure to insert the appropriate separators (/ for Mac OS and other Unix systems and \ for windows).">
 <!ENTITY additional-options "Additional options">
 <!ENTITY rename-when-sent-to-tablet "Rename files when they are sent to the tablet">
+<!ENTITY keep-one-annotated "Keep only one annotated file (detected by suffix)">
 <!ENTITY save-annotated-file "Save copy of annotated file with suffix ">
 <!ENTITY tablet-copy-information "By default, getting an attachment back from the tablet replaces the file saved in Zotero. When this option is enabled, zotfile instead creates a copy of the file with a specified suffix and adds this file as an additional attachment to Zotero.">
 <!ENTITY automatically-extract-annotations "Automatically extract annotations when getting PDFs back from tablet">

--- a/chrome/locale/en-US/overlay.dtd
+++ b/chrome/locale/en-US/overlay.dtd
@@ -9,8 +9,9 @@
 <!ENTITY pdf-outline.label "Get Table of Contents">
 <!ENTITY pdf-outline.tooltiptext "Get Table of Contents from pdf file.">
 <!ENTITY send-to-tablet "Send to Tablet">
-<!ENTITY send-annotation-to-tablet "Send Annotation to Tablet">
 <!ENTITY send-attachment-file-to-tablet "Send Attachment File to Tablet.">
+<!ENTITY send-annotation-to-tablet "Send Annotation to Tablet.">
+<!ENTITY send-annotation-file-to-tablet "Send Annotation File to Tablet.">
 <!ENTITY update-file-modification-time "Update File Modification Time">
 <!ENTITY sync-attachment-file "Sync attachment file on tablet with file in Zotero.">
 <!ENTITY get-from-tablet "Get from Tablet">

--- a/chrome/locale/en-US/overlay.dtd
+++ b/chrome/locale/en-US/overlay.dtd
@@ -9,6 +9,7 @@
 <!ENTITY pdf-outline.label "Get Table of Contents">
 <!ENTITY pdf-outline.tooltiptext "Get Table of Contents from pdf file.">
 <!ENTITY send-to-tablet "Send to Tablet">
+<!ENTITY send-annotation-to-tablet "Send Annotation to Tablet">
 <!ENTITY send-attachment-file-to-tablet "Send Attachment File to Tablet.">
 <!ENTITY update-file-modification-time "Update File Modification Time">
 <!ENTITY sync-attachment-file "Sync attachment file on tablet with file in Zotero.">

--- a/chrome/locale/en-US/zotfile.properties
+++ b/chrome/locale/en-US/zotfile.properties
@@ -27,6 +27,7 @@ menu.invalidTabletLocation				=	Location for tablet files is not defined or inva
 menu.itemIsInGroupLibrary				=	Selected item is in group library.
 menu.sendAttToBaseFolder				=	Send Attachment File to '%S'
 menu.sendAttToSubfolder					=	Send Attachment File to '...%S'
+menu.sendAnnToBaseFolder				=	Send Annotation File to '%S'
 menu.itemIsInNoCollection				=	Item is in no collection.
 menu.noSubfoldersDefined				=	No subfolders defined.
 menu.collection.tooltip                 =   Show items in '%S'

--- a/chrome/locale/fr-FR/options.dtd
+++ b/chrome/locale/fr-FR/options.dtd
@@ -34,7 +34,8 @@
 <!ENTITY additional-subfolders "Les sous-dossiers supplémentaires sont basés sur les métadonnées des documents Zotero. Utilisez &#37;a pour le nom de l'auteur, &#37;y pour l'année, &#37;w pour la revue/l'éditeur, ou &#37;T pour le type de document (consultez le site web de zotfile pour une liste complète). Assurez-vous d'insérer le séparateur approprié (/ pour Mac OS et autres systèmes Unix et \ pour Windows). Assurez-vous d'insérer les séparateurs appropriés (/ pour Mac OS et autres systèmes Unix et \ pour Windows).">
 <!ENTITY additional-options "Options supplémentaires">
 <!ENTITY rename-when-sent-to-tablet "Renommer les fichiers quand ils sont envoyés vers la tablette">
-<!ENTITY keep-one-annotated "Keep only one annotated file (detected by suffix)">
+<!ENTITY keep-one-annotated "
+Ne conserver qu'un seul fichier annoté (détecté par suffixe)">
 <!ENTITY save-annotated-file "Enregistrer une copie du fichier annoté avec le suffixe suivant: ">
 <!ENTITY tablet-copy-information "Par défaut, récupérer une pièce jointe de la tablette remplace le fichier sauvegardé dans Zotero. Quand cette option est activée, zotfile crée plutôt une copie du fichier avec un suffixe personnalisé et ajoute ce fichier comme une pièce jointe supplémentaire dans Zotero.">
 <!ENTITY automatically-extract-annotations "Extraire automatiquement les annotations quand les PDF sont récupérés de la tablette">

--- a/chrome/locale/fr-FR/options.dtd
+++ b/chrome/locale/fr-FR/options.dtd
@@ -34,6 +34,7 @@
 <!ENTITY additional-subfolders "Les sous-dossiers supplémentaires sont basés sur les métadonnées des documents Zotero. Utilisez &#37;a pour le nom de l'auteur, &#37;y pour l'année, &#37;w pour la revue/l'éditeur, ou &#37;T pour le type de document (consultez le site web de zotfile pour une liste complète). Assurez-vous d'insérer le séparateur approprié (/ pour Mac OS et autres systèmes Unix et \ pour Windows). Assurez-vous d'insérer les séparateurs appropriés (/ pour Mac OS et autres systèmes Unix et \ pour Windows).">
 <!ENTITY additional-options "Options supplémentaires">
 <!ENTITY rename-when-sent-to-tablet "Renommer les fichiers quand ils sont envoyés vers la tablette">
+<!ENTITY keep-one-annotated "Keep only one annotated file (detected by suffix)">
 <!ENTITY save-annotated-file "Enregistrer une copie du fichier annoté avec le suffixe suivant: ">
 <!ENTITY tablet-copy-information "Par défaut, récupérer une pièce jointe de la tablette remplace le fichier sauvegardé dans Zotero. Quand cette option est activée, zotfile crée plutôt une copie du fichier avec un suffixe personnalisé et ajoute ce fichier comme une pièce jointe supplémentaire dans Zotero.">
 <!ENTITY automatically-extract-annotations "Extraire automatiquement les annotations quand les PDF sont récupérés de la tablette">

--- a/chrome/locale/fr-FR/overlay.dtd
+++ b/chrome/locale/fr-FR/overlay.dtd
@@ -9,8 +9,9 @@
 <!ENTITY pdf-outline.label "Get Table of Contents">
 <!ENTITY pdf-outline.tooltiptext "Get Table of Contents from pdf file.">
 <!ENTITY send-to-tablet "Envoyer vers la tablette">
-<!ENTITY send-annotation-to-tablet "Send Annotation to Tablet">
 <!ENTITY send-attachment-file-to-tablet "Envoyer la pièce jointe vers la tablette.">
+<!ENTITY send-annotation-to-tablet "Envoyer l'annotation à la tablette.">
+<!ENTITY send-annotation-file-to-tablet "Envoyer le fichier d'annotation à la tablette.">
 <!ENTITY update-file-modification-time "Mettre à jout la date de modification du fichier">
 <!ENTITY sync-attachment-file "Synchroniser le fichier joint de la tablette avec le fichier dans Zotero.">
 <!ENTITY get-from-tablet "Récupérer de la tablette">

--- a/chrome/locale/fr-FR/overlay.dtd
+++ b/chrome/locale/fr-FR/overlay.dtd
@@ -9,6 +9,7 @@
 <!ENTITY pdf-outline.label "Get Table of Contents">
 <!ENTITY pdf-outline.tooltiptext "Get Table of Contents from pdf file.">
 <!ENTITY send-to-tablet "Envoyer vers la tablette">
+<!ENTITY send-annotation-to-tablet "Send Annotation to Tablet">
 <!ENTITY send-attachment-file-to-tablet "Envoyer la pièce jointe vers la tablette.">
 <!ENTITY update-file-modification-time "Mettre à jout la date de modification du fichier">
 <!ENTITY sync-attachment-file "Synchroniser le fichier joint de la tablette avec le fichier dans Zotero.">

--- a/chrome/locale/fr-FR/zotfile.properties
+++ b/chrome/locale/fr-FR/zotfile.properties
@@ -27,6 +27,7 @@ menu.invalidTabletLocation				=	L'emplacement des fichiers de la tablette n'est 
 menu.itemIsInGroupLibrary				=	Le document sélectionné est dans une bibliothèque de groupe.
 menu.sendAttToBaseFolder				=	Envoyer la pièce jointe vers '%S'
 menu.sendAttToSubfolder					=	Envoyer la pièce jointe vers '...%S'
+menu.sendAnnToBaseFolder				=	Envoyer le fichier d'annotation à '%S'
 menu.itemIsInNoCollection				=	Le document n'est dans aucune collection.
 menu.noSubfoldersDefined				=	Aucun sous-dossier n'est défini.
 menu.collection.tooltip                 =   Montrer les documents dans '%S'

--- a/chrome/locale/it-IT/options.dtd
+++ b/chrome/locale/it-IT/options.dtd
@@ -34,7 +34,8 @@
 <!ENTITY additional-subfolders "Le sottocartelle aggiuntive sono definite in base ai metadati degli oggetti di Zotero. Utilizzare &#37;a per nome autore, &#37;y per anno, &#37;w per pubblicazione/editore, oppure &#37;T per il tipo di oggetto (vedere il sito di zotfile per una lista completa). assicurarsi di inserire i separatori appropriati (/ per OS Mac e altri sistemi Unix e \ per windows).">
 <!ENTITY additional-options "Opzioni aggiuntive">
 <!ENTITY rename-when-sent-to-tablet "Rinomina i file quando sono inviati al tablet">
-<!ENTITY keep-one-annotated "Keep only one annotated file (detected by suffix)">
+<!ENTITY keep-one-annotated "
+Conserva un solo file annotato (rilevato dal suffisso)">
 <!ENTITY save-annotated-file "Salva con un suffisso la copia del file annotato ">
 <!ENTITY tablet-copy-information "Per impostazione predefinita, l'allegato scaricato dal tablet sostituisce il file salvato in Zotero. Quando questa opzione è abilitata, zotfile invece crea una copia del file con un suffisso specificato e aggiunge questo file come allegato aggiuntivo a Zotero.">
 <!ENTITY automatically-extract-annotations "Estrai automaticamente le annotazioni quando scarichi i PDF dal tablet">

--- a/chrome/locale/it-IT/options.dtd
+++ b/chrome/locale/it-IT/options.dtd
@@ -34,6 +34,7 @@
 <!ENTITY additional-subfolders "Le sottocartelle aggiuntive sono definite in base ai metadati degli oggetti di Zotero. Utilizzare &#37;a per nome autore, &#37;y per anno, &#37;w per pubblicazione/editore, oppure &#37;T per il tipo di oggetto (vedere il sito di zotfile per una lista completa). assicurarsi di inserire i separatori appropriati (/ per OS Mac e altri sistemi Unix e \ per windows).">
 <!ENTITY additional-options "Opzioni aggiuntive">
 <!ENTITY rename-when-sent-to-tablet "Rinomina i file quando sono inviati al tablet">
+<!ENTITY keep-one-annotated "Keep only one annotated file (detected by suffix)">
 <!ENTITY save-annotated-file "Salva con un suffisso la copia del file annotato ">
 <!ENTITY tablet-copy-information "Per impostazione predefinita, l'allegato scaricato dal tablet sostituisce il file salvato in Zotero. Quando questa opzione è abilitata, zotfile invece crea una copia del file con un suffisso specificato e aggiunge questo file come allegato aggiuntivo a Zotero.">
 <!ENTITY automatically-extract-annotations "Estrai automaticamente le annotazioni quando scarichi i PDF dal tablet">

--- a/chrome/locale/it-IT/overlay.dtd
+++ b/chrome/locale/it-IT/overlay.dtd
@@ -9,6 +9,7 @@
 <!ENTITY pdf-outline.label "Get Table of Contents">
 <!ENTITY pdf-outline.tooltiptext "Get Table of Contents from pdf file.">
 <!ENTITY send-to-tablet "Invia al Tablet">
+<!ENTITY send-annotation-to-tablet "Send Annotation to Tablet">
 <!ENTITY send-attachment-file-to-tablet "Invia l'Allegato al Tablet.">
 <!ENTITY update-file-modification-time "Aggiorna l'Orario di Modifica del File">
 <!ENTITY sync-attachment-file "Sincronizza l'allegato sul tablet con il file in Zotero.">

--- a/chrome/locale/it-IT/overlay.dtd
+++ b/chrome/locale/it-IT/overlay.dtd
@@ -9,8 +9,9 @@
 <!ENTITY pdf-outline.label "Get Table of Contents">
 <!ENTITY pdf-outline.tooltiptext "Get Table of Contents from pdf file.">
 <!ENTITY send-to-tablet "Invia al Tablet">
-<!ENTITY send-annotation-to-tablet "Send Annotation to Tablet">
 <!ENTITY send-attachment-file-to-tablet "Invia l'Allegato al Tablet.">
+<!ENTITY send-annotation-to-tablet "Invia annotazione al tablet.">
+<!ENTITY send-annotation-file-to-tablet "Invia file di annotazioni al tablet.">
 <!ENTITY update-file-modification-time "Aggiorna l'Orario di Modifica del File">
 <!ENTITY sync-attachment-file "Sincronizza l'allegato sul tablet con il file in Zotero.">
 <!ENTITY get-from-tablet "Scarica dal Tablet">

--- a/chrome/locale/it-IT/zotfile.properties
+++ b/chrome/locale/it-IT/zotfile.properties
@@ -27,6 +27,7 @@ menu.invalidTabletLocation				=	La posizione dei file sul tablet non è definita
 menu.itemIsInGroupLibrary				=	Oggetto selezionato in una libreria di gruppo.
 menu.sendAttToBaseFolder				=	Invia allegato al file a '%S'
 menu.sendAttToSubfolder					=	Invia file a '...%S'
+menu.sendAnnToBaseFolder				=	Invia file di annotazioni a '%S'
 menu.itemIsInNoCollection				=	Oggetto non nella collezione.
 menu.noSubfoldersDefined				=	Nessuna sottocartella definita.
 menu.collection.tooltip                 =   Mostra oggetti in '%S'

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -44,6 +44,7 @@ pref("extensions.zotfile.wildcards.user",'{}');
 pref("extensions.zotfile.tablet", false);
 pref("extensions.zotfile.tablet.dest_dir", "");
 pref("extensions.zotfile.tablet.rename", true);
+pref("extensions.zotfile.tablet.keepOneAnnotated", false);
 pref("extensions.zotfile.tablet.updateAlwaysShow", false);
 pref("extensions.zotfile.tablet.updateExtractAnnotations", false);
 pref("extensions.zotfile.tablet.dest_dir_relativePath", true);


### PR DESCRIPTION
This mainly helps #226 .

![image](https://user-images.githubusercontent.com/19565938/90197612-6c1c8a80-ddcf-11ea-9aee-7c3c0616644d.png)

![image](https://user-images.githubusercontent.com/19565938/90197622-7474c580-ddcf-11ea-8bdd-d3cf5cbcb025.png)

1. when disable `rename file when send to ...` and enable `store copy of annotaion with suffix`, the option `Keep only one annotated file (detected by file)`
2. when enable `keep only one annotation`: 
    - Send origin.pdf: get origin_suffix.pdf back (same as store copy)
    - Send origin_suffix.pdf: get origin_suffix.pdf by replacement (same as not store copy)
3. Add menu item - Send Annotation to Tablet
  This will send the file which has most suffix in selecting files.
  For example,
    - item contains (A, A_suffix, A_suffix_suffix_suffix): only send A_suffix_suffix_suffix
    - select (A, A_suffix_suffix): only send A_suffix_suffix
    - select (A) : send A
  Note, `Send Annotation to Tablet` only consider the selecting files. Thus, even if there is A_suffix in the last example, it still send  A to tablet because do not select A, A_suffix together. To avoid missing selection, suggest to apply `Send Annotation to Tablet` on item not files.

I am not entirely sure how to build the menu item. Some hint/comments are helpful.
Currently, I do not find a way to add `Send Annotation to Tablet` for subfolder.
Also, the text on de/it/fr are done by google translation.
All behavior depends on string, so it does not work on the inconsistent filename and different suffix (will be original behavior)

I am not familiar with javascript.
Also, I am a new user of Zotero, so I am not sure whether this behavior make sense for others.
any comment is welcome