### PR TITLE
Change menu item name from *Rename Attachments* to *Rename and Move* …

### DIFF
--- a/chrome/locale/en-US/overlay.dtd
+++ b/chrome/locale/en-US/overlay.dtd
@@ -2,7 +2,7 @@
 <!ENTITY zotfile-attach-file.tooltiptext "Move and attach last file in user defined folder to selected Zotero item">
 <!ENTITY zotfile-manage-attachments.label "Manage Attachments">
 <!ENTITY warning.label "Warning">
-<!ENTITY renameSelectedAttachments.label "Rename Attachments">
+<!ENTITY renameSelectedAttachments.label "Rename and Move">
 <!ENTITY renameSelectedAttachments.tooltiptext "Move and rename existing Attachments from selected Zotero item">
 <!ENTITY extract-annotations.label "Extract Annotations">
 <!ENTITY extract-annotations.tooltiptext "Extract Annotations and Highlighted Text from pdf file.">


### PR DESCRIPTION
…to better reflect the function that is executed.

The omission of "Move" is the main source of confusion for new users of Zotfile.
I am aware that the tooltip explains the action more precisely, but Isee no reason why the Menu-Item itself should not also be precise.

If this has been discussed and rejected before, please ignore. 