### PR TITLE
Modified warning message to include unsupported file

### DIFF
--- a/chrome/locale/en-US/zotfile.properties
+++ b/chrome/locale/en-US/zotfile.properties
@@ -4,7 +4,7 @@ menu.preferences                        =   ZotFile Preferences...
 
 general.warning							=	ZotFile Warning
 general.warning.skippedAtt				=	ZotFile Warning: Skipped attachments
-general.warning.skippedAtt.msg			=	Attachments skipped because they are top-level items, snapshots or the file does not exist.
+general.warning.skippedAtt.msg			=	Attachments skipped because they are top-level items, snapshots, an avoided filetype, or the file does not exist.
 general.warning.skippedAtt.tablet.msg	=	Attachments skipped because they are already renamed, on the tablet, top-level items, snapshots or the file does not exist.
 general.error							=	ZotFile Error
 general.report							=	ZotFile Report


### PR DESCRIPTION
As described in issue #497 , the warning message should include the case that the extension is "not correct." I think it would be helpful to modify the warning message so that it indicates the exact source of the error, but that's beyond what I'm willing to fix at this moment.