### PR TITLE
Zotero pdf extraction footnote and eof page number.

### DIFF
--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -132,4 +132,7 @@ pref("extensions.zotfile.pdfExtraction.localeDateInNote", true);
 pref("extensions.zotfile.pdfExtraction.colorNotes", false);
 pref("extensions.zotfile.pdfExtraction.colorAnnotations", false);
 pref("extensions.zotfile.pdfExtraction.colorCategories", '{"Black": "#000000", "White": "#FFFFFF", "Gray": "#808080", "Red": "#FF0000", "Orange": "#FFA500", "Yellow": "#FFFF00", "Green": "#00FF00", "Cyan": "#00FFFF", "Blue": "#0000FF", "Magenta": "#FF00FF"}');
+pref("extensions.zotfile.pdfExtraction.formatEndOfPage","<p><b>(page: %(page))</b></p>");
+pref("extensions.zotfile.pdfExtraction.formatFootNoteAddIfChanged", "(page: %(page)): %(uri)");
+pref("extensions.zotfile.pdfExtraction.createFootnote", false);
 //pref("extensions.zotfile.pdfExtraction.format", '"<p>%(markup)s" %(cite)s</p><br><p>%(note)s</p><br>');


### PR DESCRIPTION
**Hi,** 
I am using zotfile for extracting annotations from pdfs. There is no other solution. for this task :D .
I added formattable page numbers by checking every annotations page number when it changes adds formatted text.
I added footnote functionality . Code creates an footnote array. when there is a change in data of formatted text adds it to array . finally adds all items in footnote to end of file. it can be used as anchored links, Page links, etc. 
I will use this functionality with mdnotes.  Lots of URL's in text distracting so sending them to footnote seems legit option.
At default settings it adds page numbers after last annotation of page which can be changed by configuration settings.
**I am not a coder but trying to learn.**