### PR TITLE
Add epub to default filetypes

### DIFF
--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -2,7 +2,7 @@ pref("extensions.zotfile.debug",false);
 pref("extensions.zotfile.source_dir_ff",true);
 pref("extensions.zotfile.source_dir","");
 pref("extensions.zotfile.dest_dir", "");
-pref("extensions.zotfile.filetypes", "pdf,doc,docx,txt,rtf,djvu");
+pref("extensions.zotfile.filetypes", "pdf,doc,docx,txt,rtf,djvu,epub");
 pref("extensions.zotfile.useFileTypes", true);
 pref("extensions.zotfile.allFiles", false);
 pref("extensions.zotfile.useZoteroToRename", false);


### PR DESCRIPTION
Zotfile is great for managing ebooks, and .epub is the most common format out there. Therefore I would like to suggest adding epub files to the default set of filetypes that are renamed by Zotfile.

Related issue: #517 