### PR TITLE
New wildcard function for replace

### DIFF
--- a/chrome/content/zotfile/wildcards.js
+++ b/chrome/content/zotfile/wildcards.js
@@ -270,12 +270,16 @@ Zotero.ZotFile.Wildcards = new function() {
                 var obj = operations[i],
                     regex = obj.regex,
                     replacement = ('replacement' in obj) ? obj.replacement : "",
+                    replacementFunction = ('replacementFunction' in obj) ? obj.replacementFunction : "",
                     flags = ('flags' in obj) ? obj.flags : "g",
                     group = ('group' in obj) ? obj.group : 0,
                     re = new RegExp(regex, flags);
                 // replace string
                 /*https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace*/
                 if (obj.function == "replace") {
+                    if ('replacementFunction' in obj) {
+                        replacement = new Function(...replacementFunction.arguments, replacementFunction.body);
+                    }
                     transformed_value = transformed_value.replace(re, replacement);
                 }
                 // search for matches

--- a/chrome/content/zotfile/wildcards.js
+++ b/chrome/content/zotfile/wildcards.js
@@ -245,44 +245,61 @@ Zotero.ZotFile.Wildcards = new function() {
                 output = '';
             // get field
             if (typeof(field)=='string')
-                output = (field in addFields) ? addFields[field] : item.getField(field, false, true);
+                if (field in addFields)
+                    output = (Array.isArray(addFields[field])) ? Object.assign([], addFields[field]) : addFields[field];
+                else
+                    output = item.getField(field, false, true);
             if (typeof(field)=='object')
                 output = itemtypeWildcard(item, field);
             // operations
-            if(operations!==undefined) {
-                for (var i = 0; i < operations.length; ++i) {
-                    var obj = operations[i],
-                        regex = obj.regex,
-                        replacement = ('replacement' in obj) ? obj.replacement : "",
-                        flags = ('flags' in obj) ? obj.flags : "g",
-                        group = ('group' in obj) ? obj.group : 0,
-                        re = new RegExp(regex, flags);
-                    // replace string
-                    /*https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace*/
-                    if(obj.function=="replace")
-                        output = output.replace(re, replacement);
-                    // search for matches
-                    /*https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec*/
-                    if(obj.function=="exec") {
-                        var match = re.exec(output);
-                        output = (match===null) ? output : match[group];
+            if (operations !== undefined) {
+                if (Array.isArray(output)) {
+                    for (var i = 0; i < output.length; ++i) {
+                        output[i] = applyRegexOperations(output[i], operations)
                     }
-		    if(obj.function=="abbreviate") {
-			output = abbreviateField(output);
-		    }
-                    // simple functions
-                    if(obj.function=="toLowerCase")
-                        output = output.toLowerCase();
-                    if(obj.function=="toUpperCase")
-                        output = output.toUpperCase();
-                    if(obj.function=="trim")
-                        output = output.trim();
-                    if(obj.function=="truncateTitle")
-                        output = truncateTitle(output);
+                } else {
+                    output = applyRegexOperations(output, operations)
                 }
             }
             // return
             return output;
+        };
+        var applyRegexOperations = function (value, operations) {
+            let transformed_value = value;
+            for (var i = 0; i < operations.length; ++i) {
+                var obj = operations[i],
+                    regex = obj.regex,
+                    replacement = ('replacement' in obj) ? obj.replacement : "",
+                    flags = ('flags' in obj) ? obj.flags : "g",
+                    group = ('group' in obj) ? obj.group : 0,
+                    re = new RegExp(regex, flags);
+                // replace string
+                /*https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace*/
+                if (obj.function == "replace") {
+                    transformed_value = transformed_value.replace(re, replacement);
+                }
+                // search for matches
+                /*https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec*/
+                if (obj.function == "exec") {
+                    var match = re.exec(transformed_value);
+                    transformed_value = (match === null) ? transformed_value : match[group];
+                }
+                if (obj.function == "abbreviate") {
+                    transformed_value = abbreviateField(transformed_value);
+                }
+                // simple functions
+                if (obj.function == "toLowerCase")
+                    transformed_value = transformed_value.toLowerCase();
+                if (obj.function == "toUpperCase")
+                    transformed_value = transformed_value.toUpperCase();
+                if (obj.function == "trim")
+                    transformed_value = transformed_value.trim();
+                if (obj.function == "truncateTitle")
+                    transformed_value = truncateTitle(transformed_value);
+            }
+
+            // return
+            return transformed_value;
         };
         // get wildcards object from preferences
         var wildcards = JSON.parse(Zotero.ZotFile.getPref("wildcards.default"));


### PR DESCRIPTION
_Please note that the PR include my previous PR #544._

Currently for a "rename and move" action, it is not possible to specify a user-defined wildcard that **use a [replace function](http://zotfile.com/#user-defined-wildcards) with something other than a string as replacement**. For example, if I want my files to be moved into directories named after my collection names after they have been transformed according to the "every word starts with a capital letter" rule, this is not possible.

![00](https://user-images.githubusercontent.com/13517389/127071238-a21e4511-a04d-4e1b-879d-b57be7894d83.png)
![01](https://user-images.githubusercontent.com/13517389/127071244-494da4b0-de0c-4d81-a020-9ab2476adf4f.png)

To perform the operation described above, the regex and json to be used are the following:
```json
"2": {
    "default": {
      "field": "collectionPaths",
      "operations": [
        {
          "function": "replace",
          "regex": "(^|\\s+|_+|\\/)(\\w{1})(?![nd|r]{1})",
          "replacement": "????"
        }
      ]
    }
  }
```
But it is clear that it is impossible to specify what to replace the matches with. So in this PR, I propose the possibility to use as replacement "a string" (the current behavior) or a "js function". Behind the scene, this means that we won't just use `string.replace` with a string as parameter, but rather, `string.replace` with a function as parameter ([see the js doc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace)).

Thus with this PR, it is now possible to perform a complex operation on a match using this json format:

```json
"<id>": {
    "default": {
      "field": "<a field>",
      "operations": [
        {
          "function": "replace",
          "regex": "<a regex>",
          "replacementFunction": {
            "arguments": [
              "<arg1>",
              "<arg2>",
              "...",
              "<argn>"
            ],
            "body": "<my js code>; return <my returned string>;"
          }
        }
      ]
    }
```
Applied to my initial example, this would give :
```json
"2": {
    "default": {
      "field": "collectionPaths",
      "operations": [
        {
          "function": "replace",
          "regex": "(^|\\s+|_+|\\/)(\\w{1})(?![nd|r]{1})",
          "replacementFunction": {
            "arguments": [
              "match",
              "g1",
              "g2",
              "offset",
              "string"
            ],
            "body": "return g1.concat(g2.toUpperCase());"
          }
        }
      ]
    }
```
