### PR TITLE
Remove use of deprecated saveSelection() 

### DIFF
--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -875,7 +875,7 @@ Zotero.ZotFile = new function() {
         if (att.isTopLevelItem()) throw('Zotero.ZotFile.renameAttachment(): Attachment is top-level item.');
         // set variables
         var win = Services.wm.getMostRecentWindow("navigator:browser"),
-            selection = win.ZoteroPane.itemsView.saveSelection(),
+            selection = win.ZoteroPane.itemsView.getSelectedItems(true),
             att_id = att.id,
             linkmode = att.attachmentLinkMode,
             item = Zotero.Items.get(att.parentItemID),


### PR DESCRIPTION
Update the code to use `getSelectedItems(true)` as recommended by commit
`ba7d0a1` of zotero/zotero.

This fixes #549 