### PR TITLE
Add %b wildcard to docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ ZotFile renames files based on bibliographic information from the currently sele
 
 ##### Wildcards
 - `%a` last names of authors (not editors etc) or inventors. The maximum number of authors are changed under 'Additional Settings'.
+- `%b` citation key
 - `%I` author initials.
 - `%F` author's last name with first letter of first name (e.g. EinsteinA).
 - `%A` first letter of author (useful for subfolders)


### PR DESCRIPTION
Include the %b citation key in the list of accepted wildcards. This wildcard has been available for a while (at least as recently as 2019 https://github.com/jlegewie/zotfile/issues/386) but didn't make it into the docs