### PR TITLE
Zotero 6 compatibility

### DIFF
--- a/chrome/content/zotfile/options.js
+++ b/chrome/content/zotfile/options.js
@@ -27,6 +27,9 @@ var updatePreferenceWindow = function (which) {
         updatePDFToolsStatus();
         updateFolderIcon("all", false);
         this.temp = this.getPref('tablet.dest_dir');
+        if (Zotero.ZotFile.isZotero6OrLater) {
+            document.getElementById('extract-annotations-box').hidden = true;
+        }
         /*if(document.getElementById('pref-zotfile-tablet-mode').value==2) {
             document.getElementById('id-zotfile-tablet-storeCopyOfFile').disabled = true;
             document.getElementById('id-zotfile-tablet-storeCopyOfFile_suffix').disabled = true;

--- a/chrome/content/zotfile/options.xul
+++ b/chrome/content/zotfile/options.xul
@@ -243,7 +243,7 @@
 
 					<!-- ADVANCED SETTINGS -->
 					<tabpanel orient="vertical">
-						<groupbox>
+						<groupbox id="extract-annotations-box">
 							<caption label="&extract-annotations;"/>
 							<label value="&extract-annotations-and-highlighted-text;"/>
 							<separator/>

--- a/chrome/content/zotfile/ui.js
+++ b/chrome/content/zotfile/ui.js
@@ -106,7 +106,7 @@ Zotero.ZotFile.UI = new function() {
                 menu.childNodes[m.warning2].setAttribute('label',this.ZFgetString('menu.itemHasNoAtts'));
             }
             // add 'Extract annotations'
-            if(this.getPref('pdfExtraction.MenuItem')) show.push(m.extractanno);
+            if(!Zotero.ZotFile.isZotero6OrLater && this.getPref('pdfExtraction.MenuItem')) show.push(m.extractanno);
             if(this.getPref('pdfOutline.menuItem')) show.push(m.getoutline);
             // tablet menu part
             if(this.getPref('tablet') && menu_att) {

--- a/chrome/content/zotfile/zotfile.js
+++ b/chrome/content/zotfile/zotfile.js
@@ -79,6 +79,7 @@ Zotero.ZotFile = new function() {
                 var version = addon.version;
                 if(version != previous_version) Zotero.ZotFile.versionChanges(version);
             });
+            this.isZotero6OrLater = Services.vc.compare(Zotero.version, '5.0.96.999') >= 0;
             // run in future to not burden start-up
             this.futureRun(function() {
                 // determine folder seperator depending on OS
@@ -916,6 +917,24 @@ Zotero.ZotFile = new function() {
                 note.setNote(content);
                 note.saveTx();
             });
+            // transfer various attachment data
+            //
+            // should stay in sync with Zotero.Attachments.convertLinkedFileToStoredFile()
+            if (this.isZotero6OrLater) {
+                // move child annotations and embedded-image attachments
+                yield Zotero.Items.moveChildItems(att, attNew);
+                // copy relations pointing to the old item
+                yield Zotero.Relations.copyObjectSubjectRelations(att, attNew);
+                // transfer full-text item index
+                try {
+                    yield Zotero.DB.executeTransaction(async function () {
+                        await Zotero.Fulltext.transferItemIndex(att, attNew);
+                    });
+                }
+                catch (e) {
+                    Zotero.logError(e);
+                }
+            }
             // erase old attachment, remove file and folder
             yield att.eraseTx();
             yield OS.File.remove(path);
@@ -962,6 +981,24 @@ Zotero.ZotFile = new function() {
                 note.setNote(content);
                 note.saveTx();
             });
+            // transfer various attachment data
+            //
+            // should stay in sync with Zotero.Attachments.convertLinkedFileToStoredFile()
+            if (this.isZotero6OrLater) {
+                // move child annotations and embedded-image attachments
+                yield Zotero.Items.moveChildItems(att, attNew);
+                // copy relations pointing to the old item
+                yield Zotero.Relations.copyObjectSubjectRelations(att, attNew);
+                // transfer full-text item index
+                try {
+                    yield Zotero.DB.executeTransaction(async function () {
+                        await Zotero.Fulltext.transferItemIndex(att, attNew);
+                    });
+                }
+                catch (e) {
+                    Zotero.logError(e);
+                }
+            }
             // erase old attachment, remove file and folder
             yield att.eraseTx();
             // notification and return

--- a/install.rdf
+++ b/install.rdf
@@ -17,14 +17,14 @@
       <Description>
         <em:id>zotero@chnm.gmu.edu</em:id>
         <em:minVersion>5.0.0</em:minVersion>
-        <em:maxVersion>5.*</em:maxVersion>
+        <em:maxVersion>6.0.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     <em:targetApplication>
       <Description>
         <em:id>juris-m@juris-m.github.io</em:id>
         <em:minVersion>4.999</em:minVersion>
-        <em:maxVersion>5.*</em:maxVersion>
+        <em:maxVersion>6.0.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     <em:localized>


### PR DESCRIPTION
See the individual commits for details, but this 1) fixes a major data-loss bug, 2) addresses widespread user confusion with ZotFile and the new built-in PDF reader, and 3) prevents ZotFile from being disabled as soon as we bump the version number to 6.0, which we'll be doing shortly.

Re: Extract Annotations, some examples of user confusion:

https://forums.zotero.org/discussion/93927/internal-pdf-viewer-not-extracting-highlights
https://forums.zotero.org/discussion/93506/a-way-to-store-annotations-of-multiple-documents-to-the-files-at-once
https://forums.zotero.org/discussion/93384/new-beta-pdf-viewer-reader-possible-bug-or-work-around-help-please
https://forums.zotero.org/discussion/92812/beta-build-zotfile-extract-highlights-doesnt-work
https://forums.zotero.org/discussion/92684/highlights-disappear
https://forums.zotero.org/discussion/comment/393139/#Comment_393139
https://forums.zotero.org/discussion/92387/exporting-annotations
https://forums.zotero.org/discussion/91812/problem-with-zoteros-beta-pdf-reader-and-zotfiles-annotations-export
https://forums.zotero.org/discussion/91645/highlights-made-on-a-pdf-file-on-zotero-ios-is-not-synced

(I stopped at this point, but there were more.)