### PR TITLE
Restore active tab label in preferences on macOS Big Sur and later

### DIFF
--- a/chrome/content/zotfile/options.xul
+++ b/chrome/content/zotfile/options.xul
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero-platform/content/preferences.css"?>
+<?xml-stylesheet href="chrome://zotero-platform-version/content/style.css"?>
 
 <!DOCTYPE window SYSTEM "chrome://zotfile/locale/options.dtd">
 


### PR DESCRIPTION
See zotero/zotero@7c201f5d59