### PR TITLE
Removing rich text formatting from title string

### DIFF
--- a/chrome/content/zotfile/wildcards.js
+++ b/chrome/content/zotfile/wildcards.js
@@ -85,7 +85,8 @@ Zotero.ZotFile.Wildcards = new function() {
 
         // replace forbidden characters with meaningful alternatives (they can only apear in the middle of the text at this point)
         title = title.replace(/[\/\\]/g, '-');
-        title = title.replace(/[\*|"<>]/g, '');
+        title = title.replace(/<[\w\s"<=\/]+>|[\*|"<>]/g, '');
+        //title = title.replace(/[\*|"<>]/g, '');
         title = title.replace(/[\?:]/g, ' -');
         return(title);
     }

--- a/chrome/content/zotfile/wildcards.js
+++ b/chrome/content/zotfile/wildcards.js
@@ -84,9 +84,9 @@ Zotero.ZotFile.Wildcards = new function() {
         }
 
         // replace forbidden characters with meaningful alternatives (they can only apear in the middle of the text at this point)
+        title = title.replace(/<[\w\s"<=\/]+>/g, ''); // Removing rich text formatting
         title = title.replace(/[\/\\]/g, '-');
-        title = title.replace(/<[\w\s"<=\/]+>|[\*|"<>]/g, '');
-        //title = title.replace(/[\*|"<>]/g, '');
+        title = title.replace(/[\*|"<>]/g, '');
         title = title.replace(/[\?:]/g, ' -');
         return(title);
     }

--- a/install.rdf
+++ b/install.rdf
@@ -5,7 +5,7 @@
   <Description about="urn:mozilla:install-manifest">
     <em:id>zotfile@columbia.edu</em:id>
     <em:name>ZotFile</em:name>
-    <em:version>5.1.0</em:version>
+    <em:version>5.1.0.9000</em:version>
     <em:type>2</em:type>
     <em:multiprocessCompatible>true</em:multiprocessCompatible>
     <em:creator>Joscha Legewie</em:creator>


### PR DESCRIPTION
Scientific publications are often using (font) formatting such as italic, bold, etc. to satisfy regulations, which are required by specific codices. For example, scientific species names formatted italic, such as "_Triticum aestivum_ subsp. _aestivum_" or "_Berberis_ spp." (common wheat). To achieve that for the publication title, `Zotero` allow using rich text formatting based on `HTML` code. But if titles have been already formatted, `ZotFile` just remove special characters defined by `wildcard.js` or a user-specific wildcard have to be implemented, which isn't that user-friendly. It is highly likely, that this user case doesn't concern a just few people, and therefore I suggest including this additional replacement rule into the `wildcard.js`.

### Example
Formatted title: 
```html 
Diversity of <span class="nocase"><i>Puccinia striiformis</i></span> on cereals and grasses
```

Expected result:
```
Diversity_of_Puccinia_striiformis_on_cereals_and_grasses
```

Result with current `ZotFile` version:
```
Diversity_of_span_class=nocaseiPuccinia_striiformis-i-span_on_cereals_and_grasses
```
(Where just the special characters `"`, `<`, and `>` have been replaced, but not the `HTML` syntax.)