### PR TITLE
Fix editor wildcards

### DIFF
--- a/chrome/content/zotfile/wildcards.js
+++ b/chrome/content/zotfile/wildcards.js
@@ -133,16 +133,7 @@ Zotero.ZotFile.Wildcards = new function() {
     function formatAuthors(item) {
         // get creator and create authors string
         var itemType = Zotero.ItemTypes.getName(item.itemTypeID);
-        var creatorTypeIDs;
-        if (itemType == 'book') {
-        	creatorTypeIDs = [
-				Zotero.CreatorTypes.getID('author'),
-				Zotero.CreatorTypes.getID('editor')
-			];
-		}
-        else {
-        	creatorTypeIDs = [Zotero.CreatorTypes.getPrimaryIDForType(item.itemTypeID)];
-        }
+        var creatorTypeIDs  = [Zotero.CreatorTypes.getPrimaryIDForType(item.itemTypeID)];
         var add_etal = Zotero.ZotFile.getPref("add_etal");
         var author = "", author_lastf="", author_initials="", author_lastg = "";
         var creators = item.getCreators();
@@ -186,7 +177,7 @@ Zotero.ZotFile.Wildcards = new function() {
             lastAuthor_lastInitial = creators[creators.length - 1].lastName.substr(0, 1).toUpperCase();
         }
         // get creator and create editors string
-        var editorType = [3,4,5,27,29];
+        var editorType = [Zotero.CreatorTypes.getID('editor')];
         var editor = "", editor_lastf="", editor_initials="";
         var numeditors = creators.length;
         for (var i = 0; i < creators.length; ++i) {
@@ -199,7 +190,7 @@ Zotero.ZotFile.Wildcards = new function() {
             if (j < numeditors && editorType.indexOf(creators[i].creatorTypeID) != -1) {
                 if (editor !== "") editor += delimiter + creators[i].lastName;
                 if (editor === "") editor = creators[i].lastName;
-                var lastfe =  creators[i].lastName + creators[i].firstName.substr(0, 1).toUpperCase();
+                var lastf =  creators[i].lastName + creators[i].firstName.substr(0, 1).toUpperCase();
                 if (editor_lastf !== "") editor_lastf += delimiter + lastf;
                 if (editor_lastf === "") editor_lastf = lastf;
                 var initials = creators[i].firstName.substr(0, 1).toUpperCase() + creators[i].lastName.substr(0, 1).toUpperCase()


### PR DESCRIPTION
Includes following changes:

- %a wildcard used to return both authors and editors, contrary to the documentation. Changed to return only authors, and code simplified.
- editor wild cards used to return undefined value. Removed a hardcoded list of creatorTypes that did not include "editor" and fixed a typo. 

Please see issues #516 and #561 especially this comment: https://github.com/jlegewie/zotfile/issues/561#issuecomment-1294300530

This is my first ever pull request, apologies if this isn't done correctly.